### PR TITLE
Filter Android Pay payment methods from the list of vaulted payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Update `android-card-form` to 3.0.3
 
-## ## ##3.0.3
+## 3.0.3
 
 * Fix an issue where Drop-in would not repect the `mAndroidPayEnabled` flag (thanks @bblackbelt)
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -41,11 +41,13 @@ import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 import com.braintreepayments.api.interfaces.ConfigurationListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
+import com.braintreepayments.api.models.AndroidPayCardNonce;
 import com.braintreepayments.api.models.Authorization;
 import com.braintreepayments.api.models.ClientToken;
 import com.braintreepayments.api.models.Configuration;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static android.view.animation.AnimationUtils.loadAnimation;
@@ -259,11 +261,19 @@ public class DropInActivity extends Activity implements ConfigurationListener, B
     }
 
     @Override
-    public void onPaymentMethodNoncesUpdated(final List<PaymentMethodNonce> paymentMethodNonces) {
-        if (paymentMethodNonces.size() > 0) {
+    public void onPaymentMethodNoncesUpdated(List<PaymentMethodNonce> paymentMethodNonces) {
+        List<PaymentMethodNonce> filteredPaymentMethodNonces = new ArrayList<>(paymentMethodNonces);
+        for (PaymentMethodNonce paymentMethodNonce : paymentMethodNonces) {
+            if (paymentMethodNonce instanceof AndroidPayCardNonce) {
+                filteredPaymentMethodNonces.remove(paymentMethodNonce);
+            }
+        }
+
+        if (filteredPaymentMethodNonces.size() > 0) {
             mSupportedPaymentMethodsHeader.setText(R.string.bt_other);
             mVaultedPaymentMethodsContainer.setVisibility(View.VISIBLE);
-            mVaultedPaymentMethodsView.setAdapter(new VaultedPaymentMethodsAdapter(this, paymentMethodNonces));
+            mVaultedPaymentMethodsView.setAdapter(new VaultedPaymentMethodsAdapter(this,
+                    filteredPaymentMethodNonces));
         } else {
             mSupportedPaymentMethodsHeader.setText(R.string.bt_select_payment_method);
         }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -150,18 +150,17 @@ public class DropInActivity extends Activity implements ConfigurationListener, B
             AndroidPay.isReadyToPay(mBraintreeFragment, new BraintreeResponseListener<Boolean>() {
                 @Override
                 public void onResponse(Boolean isReadyToPay) {
-                    createAndSetPaymentMethodsAdapter(configuration, isReadyToPay);
+                    showSupportedPaymentMethods(configuration, isReadyToPay);
                 }
             });
         } else {
-            createAndSetPaymentMethodsAdapter(configuration, false);
+            showSupportedPaymentMethods(configuration, false);
         }
     }
 
-    private void createAndSetPaymentMethodsAdapter(final Configuration configuration, final boolean withAndroidPay) {
-        mSupportedPaymentMethodListView.setAdapter(new SupportedPaymentMethodsAdapter(
-                DropInActivity.this, configuration, withAndroidPay, mClientTokenPresent,
-                DropInActivity.this));
+    private void showSupportedPaymentMethods(Configuration configuration, boolean androidPaySupported) {
+        mSupportedPaymentMethodListView.setAdapter(new SupportedPaymentMethodsAdapter(this,
+                configuration, androidPaySupported, mClientTokenPresent, this));
         mLoadingViewSwitcher.setDisplayedChild(1);
         fetchPaymentMethodNonces();
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
@@ -107,7 +107,6 @@ public class EditCardView extends LinearLayout implements OnCardFormFieldFocused
             }
 
             if (formErrors.errorFor("cvv") != null) {
-
                 mCardForm.setCvvError(getContext().getString(R.string.bt_cvv_invalid,
                         getContext().getString(
                                 mCardForm.getCardEditText().getCardType().getSecurityCodeName())));

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -365,7 +365,21 @@ public class DropInActivityUnitTest {
         setup(httpClient);
 
         assertThat(mActivity.findViewById(R.id.bt_vaulted_payment_methods)).isShown();
-        assertEquals(3, ((RecyclerView) mActivity.findViewById(R.id.bt_vaulted_payment_methods)).getAdapter().getItemCount());
+        assertEquals(2, ((RecyclerView) mActivity.findViewById(R.id.bt_vaulted_payment_methods)).getAdapter().getItemCount());
+        assertThat((TextView) mActivity.findViewById(R.id.bt_supported_payment_methods_header)).hasText(R.string.bt_other);
+    }
+
+    @Test
+    public void onPaymentMethodNoncesUpdated_filtersOutVaultedAndroidPayCardNonces() {
+        BraintreeUnitTestHttpClient httpClient = new BraintreeUnitTestHttpClient()
+                .configuration(new TestConfigurationBuilder().build())
+                .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
+                        stringFromFixture("responses/get_payment_methods_android_pay_response.json"));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        setup(httpClient);
+
+        assertThat(mActivity.findViewById(R.id.bt_vaulted_payment_methods)).isShown();
+        assertEquals(2, ((RecyclerView) mActivity.findViewById(R.id.bt_vaulted_payment_methods)).getAdapter().getItemCount());
         assertThat((TextView) mActivity.findViewById(R.id.bt_supported_payment_methods_header)).hasText(R.string.bt_other);
     }
 

--- a/Drop-In/src/test/resources/fixtures/responses/get_payment_methods_android_pay_response.json
+++ b/Drop-In/src/test/resources/fixtures/responses/get_payment_methods_android_pay_response.json
@@ -1,6 +1,15 @@
 {
   "paymentMethods": [
     {
+      "type": "AndroidPayCard",
+      "nonce": "fake-android-pay-nonce",
+      "description": "Visa 1111",
+      "details": {
+        "cardType": "Visa",
+        "lastTwo": "11"
+      }
+    },
+    {
       "type": "CreditCard",
       "nonce": "123456-12345-12345-a-adfa",
       "description": "ending in ••11",


### PR DESCRIPTION
The [docs to not recommend vaulting Android Pay payment methods](https://developers.braintreepayments.com/guides/android-pay/server-side), but when they are vaulted, they should not show up in the list of vaulted payment methods in Drop-in.