### PR TITLE
Run 3D Secure verifications on vaulted cards

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
@@ -4,9 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.IntDef;
-import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.telephony.PhoneNumberUtils;
 import android.text.TextUtils;
@@ -15,7 +13,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ViewSwitcher;
 
-import com.braintreepayments.api.BraintreeFragment;
 import com.braintreepayments.api.Card;
 import com.braintreepayments.api.ThreeDSecure;
 import com.braintreepayments.api.UnionPay;
@@ -37,10 +34,8 @@ import com.braintreepayments.api.interfaces.BraintreeErrorListener;
 import com.braintreepayments.api.interfaces.ConfigurationListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.UnionPayListener;
-import com.braintreepayments.api.models.Authorization;
 import com.braintreepayments.api.models.BraintreeRequestCodes;
 import com.braintreepayments.api.models.CardBuilder;
-import com.braintreepayments.api.models.ClientToken;
 import com.braintreepayments.api.models.Configuration;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 import com.braintreepayments.api.models.UnionPayCapabilities;
@@ -52,7 +47,7 @@ import java.lang.annotation.RetentionPolicy;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
-public class AddCardActivity extends AppCompatActivity implements ConfigurationListener,
+public class AddCardActivity extends BaseActivity implements ConfigurationListener,
         AddPaymentUpdateListener, PaymentMethodNonceCreatedListener, BraintreeErrorListener,
         BraintreeCancelListener, UnionPayListener {
 
@@ -81,10 +76,6 @@ public class AddCardActivity extends AppCompatActivity implements ConfigurationL
     private boolean mUnionPayCard;
     private boolean mUnionPayDebitCard;
 
-    private DropInRequest mDropInRequest;
-    private BraintreeFragment mBraintreeFragment;
-    private Configuration mConfiguration;
-    private boolean mClientTokenPresent;
     private String mEnrollmentId;
 
     @State
@@ -118,8 +109,6 @@ public class AddCardActivity extends AppCompatActivity implements ConfigurationL
 
         enterState(LOADING);
 
-        mDropInRequest = getIntent().getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
-
         try {
             mBraintreeFragment = getBraintreeFragment();
         } catch (InvalidArgumentException e) {
@@ -130,23 +119,6 @@ public class AddCardActivity extends AppCompatActivity implements ConfigurationL
         }
 
         mBraintreeFragment.sendAnalyticsEvent("card.selected");
-    }
-
-    @VisibleForTesting
-    protected BraintreeFragment getBraintreeFragment() throws InvalidArgumentException {
-        if (TextUtils.isEmpty(mDropInRequest.getAuthorization())) {
-            throw new InvalidArgumentException("A client token or client key must be specified " +
-                    "in the " + DropInRequest.class.getSimpleName());
-        }
-
-        try {
-            mClientTokenPresent =
-                    Authorization.fromString(mDropInRequest.getAuthorization()) instanceof ClientToken;
-        } catch (InvalidArgumentException e) {
-            mClientTokenPresent = false;
-        }
-
-        return BraintreeFragment.newInstance(this, mDropInRequest.getAuthorization());
     }
 
     @Override

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
@@ -275,9 +275,7 @@ public class AddCardActivity extends BaseActivity implements ConfigurationListen
                     .postalCode(mEditCardView.getCardForm().getPostalCode())
                     .validate(mClientTokenPresent);
 
-            if (mDropInRequest.shouldRequestThreeDSecureVerification() &&
-                    !TextUtils.isEmpty(mDropInRequest.getAmount()) &&
-                    mConfiguration.isThreeDSecureEnabled()) {
+            if (shouldRequestThreeDSecureVerification()) {
                 ThreeDSecure.performVerification(mBraintreeFragment, cardBuilder,
                         mDropInRequest.getAmount());
             } else {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
@@ -1,0 +1,43 @@
+package com.braintreepayments.api.dropin;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+
+import com.braintreepayments.api.BraintreeFragment;
+import com.braintreepayments.api.exceptions.InvalidArgumentException;
+import com.braintreepayments.api.models.Authorization;
+import com.braintreepayments.api.models.ClientToken;
+import com.braintreepayments.api.models.Configuration;
+
+public class BaseActivity extends AppCompatActivity {
+
+    protected DropInRequest mDropInRequest;
+    protected BraintreeFragment mBraintreeFragment;
+    protected Configuration mConfiguration;
+    protected boolean mClientTokenPresent;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mDropInRequest = getIntent().getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
+    }
+
+    protected BraintreeFragment getBraintreeFragment() throws InvalidArgumentException {
+        if (TextUtils.isEmpty(mDropInRequest.getAuthorization())) {
+            throw new InvalidArgumentException("A client token or client key must be specified " +
+                    "in the " + DropInRequest.class.getSimpleName());
+        }
+
+        try {
+            mClientTokenPresent = Authorization.fromString(mDropInRequest.getAuthorization())
+                    instanceof ClientToken;
+        } catch (InvalidArgumentException e) {
+            mClientTokenPresent = false;
+        }
+
+        return BraintreeFragment.newInstance(this, mDropInRequest.getAuthorization());
+    }
+}

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
@@ -27,8 +27,8 @@ public class BaseActivity extends AppCompatActivity {
 
     protected BraintreeFragment getBraintreeFragment() throws InvalidArgumentException {
         if (TextUtils.isEmpty(mDropInRequest.getAuthorization())) {
-            throw new InvalidArgumentException("A client token or client key must be specified " +
-                    "in the " + DropInRequest.class.getSimpleName());
+            throw new InvalidArgumentException("A client token or tokenization key must be " +
+                    "specified in the " + DropInRequest.class.getSimpleName());
         }
 
         try {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
@@ -40,4 +40,10 @@ public class BaseActivity extends AppCompatActivity {
 
         return BraintreeFragment.newInstance(this, mDropInRequest.getAuthorization());
     }
+
+    protected boolean shouldRequestThreeDSecureVerification() {
+        return mDropInRequest.shouldRequestThreeDSecureVerification() &&
+                !TextUtils.isEmpty(mDropInRequest.getAmount()) &&
+                mConfiguration.isThreeDSecureEnabled();
+    }
 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 import android.widget.ViewSwitcher;
 
 import com.braintreepayments.api.AndroidPay;
-import com.braintreepayments.api.BraintreeFragment;
 import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.PayPal;
 import com.braintreepayments.api.PaymentMethod;
@@ -43,8 +42,6 @@ import com.braintreepayments.api.interfaces.ConfigurationListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
 import com.braintreepayments.api.models.AndroidPayCardNonce;
-import com.braintreepayments.api.models.Authorization;
-import com.braintreepayments.api.models.ClientToken;
 import com.braintreepayments.api.models.Configuration;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 
@@ -53,7 +50,7 @@ import java.util.List;
 
 import static android.view.animation.AnimationUtils.loadAnimation;
 
-public class DropInActivity extends Activity implements ConfigurationListener, BraintreeCancelListener,
+public class DropInActivity extends BaseActivity implements ConfigurationListener, BraintreeCancelListener,
         BraintreeErrorListener, PaymentMethodSelectedListener, PaymentMethodNoncesUpdatedListener,
         PaymentMethodNonceCreatedListener {
 
@@ -69,12 +66,6 @@ public class DropInActivity extends Activity implements ConfigurationListener, B
     private static final String EXTRA_SHEET_SLIDE_UP_PERFORMED = "com.braintreepayments.api.EXTRA_SHEET_SLIDE_UP_PERFORMED";
     private static final String EXTRA_DEVICE_DATA = "com.braintreepayments.api.EXTRA_DEVICE_DATA";
 
-    @VisibleForTesting
-    protected DropInRequest mDropInRequest;
-
-    private BraintreeFragment mBraintreeFragment;
-    private boolean mClientTokenPresent;
-    private Configuration mConfiguration;
     private String mDeviceData;
 
     private View mBottomSheet;
@@ -93,7 +84,6 @@ public class DropInActivity extends Activity implements ConfigurationListener, B
         super.onCreate(savedInstanceState);
         setContentView(R.layout.bt_drop_in_activity);
 
-        mDropInRequest = getIntent().getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
         mBottomSheet = findViewById(R.id.bt_dropin_bottom_sheet);
         mLoadingViewSwitcher = (ViewSwitcher) findViewById(R.id.bt_loading_view_switcher);
         mSupportedPaymentMethodsHeader = (TextView) findViewById(R.id.bt_supported_payment_methods_header);
@@ -120,23 +110,6 @@ public class DropInActivity extends Activity implements ConfigurationListener, B
         }
 
         slideUp();
-    }
-
-    @VisibleForTesting
-    protected BraintreeFragment getBraintreeFragment() throws InvalidArgumentException {
-        if (TextUtils.isEmpty(mDropInRequest.getAuthorization())) {
-            throw new InvalidArgumentException("A client token or client key must be specified " +
-                    "in the " + DropInRequest.class.getSimpleName());
-        }
-
-        try {
-            mClientTokenPresent =
-                    Authorization.fromString(mDropInRequest.getAuthorization()) instanceof ClientToken;
-        } catch (InvalidArgumentException e) {
-            mClientTokenPresent = false;
-        }
-
-        return BraintreeFragment.newInstance(this, mDropInRequest.getAuthorization());
     }
 
     @Override

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityPowerMockTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityPowerMockTest.java
@@ -45,7 +45,7 @@ public class AddCardActivityPowerMockTest {
 
         mActivity = Robolectric.buildActivity(AddCardUnitTestActivity.class).get();
 
-        setField(AddCardActivity.class, mActivity, "mBraintreeFragment", mFragment);
+        setField(BaseActivity.class, mActivity, "mBraintreeFragment", mFragment);
 
         EditCardView editCardView = mock(EditCardView.class);
         when(editCardView.getCardForm()).thenReturn(mock(CardForm.class));
@@ -125,7 +125,7 @@ public class AddCardActivityPowerMockTest {
 
     private void setConfiguration(DropInRequest dropInRequest, Configuration configuration)
             throws NoSuchFieldException, IllegalAccessException {
-        setField(AddCardActivity.class, mActivity, "mDropInRequest", dropInRequest);
-        setField(AddCardActivity.class, mActivity, "mConfiguration", configuration);
+        setField(BaseActivity.class, mActivity, "mDropInRequest", dropInRequest);
+        setField(BaseActivity.class, mActivity, "mConfiguration", configuration);
     }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
@@ -100,7 +100,7 @@ public class AddCardActivityUnitTest {
         Exception exception = (Exception) mShadowActivity.getResultIntent()
                 .getSerializableExtra(DropInActivity.EXTRA_ERROR);
         assertTrue(exception instanceof InvalidArgumentException);
-        assertEquals("A client token or client key must be specified in the DropInRequest",
+        assertEquals("A client token or tokenization key must be specified in the DropInRequest",
                 exception.getMessage());
     }
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
@@ -2,8 +2,6 @@ package com.braintreepayments.api.dropin;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.pm.ActivityInfo;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
@@ -48,12 +46,12 @@ import static com.braintreepayments.api.test.CardNumber.UNIONPAY_CREDIT;
 import static com.braintreepayments.api.test.CardNumber.UNIONPAY_DEBIT;
 import static com.braintreepayments.api.test.CardNumber.UNIONPAY_SMS_NOT_REQUIRED;
 import static com.braintreepayments.api.test.CardNumber.VISA;
+import static com.braintreepayments.api.test.PackageManagerUtils.mockPackageManagerWithThreeDSecureWebViewActivity;
 import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KEY;
 import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.assertj.android.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -79,8 +77,8 @@ public class AddCardActivityUnitTest {
 
     @Test
     public void returnsExceptionWhenBraintreeFragmentSetupFails() {
-        mActivity.dropInRequest = new DropInRequest()
-                .tokenizationKey("not a tokenization key");
+        mActivity.setDropInRequest(new DropInRequest()
+                .tokenizationKey("not a tokenization key"));
 
         mActivityController.setup();
 
@@ -93,8 +91,8 @@ public class AddCardActivityUnitTest {
 
     @Test
     public void returnsExceptionWhenAuthorizationIsEmpty() {
-        mActivity.dropInRequest = new DropInRequest()
-                .tokenizationKey(null);
+        mActivity.setDropInRequest(new DropInRequest()
+                .tokenizationKey(null));
 
         mActivityController.setup();
 
@@ -251,8 +249,8 @@ public class AddCardActivityUnitTest {
                         .build())
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_CAPABILITIES_PATH,
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -321,8 +319,8 @@ public class AddCardActivityUnitTest {
                         .build())
                 .errorResponse(BraintreeUnitTestHttpClient.TOKENIZE_CREDIT_CARD, 422,
                         stringFromFixture("responses/credit_card_error_response.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -359,8 +357,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"))
                 .errorResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH, 422,
                         stringFromFixture("responses/unionpay_enrollment_error_response.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -482,8 +480,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"))
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -511,8 +509,8 @@ public class AddCardActivityUnitTest {
                         .build())
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_CAPABILITIES_PATH,
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -535,8 +533,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"))
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -566,8 +564,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_enrollment_sms_not_required.json"))
                 .successResponse(BraintreeUnitTestHttpClient.TOKENIZE_CREDIT_CARD,
                         stringFromFixture("payment_methods/unionpay_credit_card.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_SMS_NOT_REQUIRED);
@@ -616,8 +614,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"))
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -649,8 +647,8 @@ public class AddCardActivityUnitTest {
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"))
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
-        mActivity.dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+        mActivity.setDropInRequest(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -687,14 +685,14 @@ public class AddCardActivityUnitTest {
 
     @Test
     public void showsSubmitButtonAgainWhenThreeDSecureIsCanceled() throws PackageManager.NameNotFoundException {
-        PackageManager packageManager = mockPackageManager();
+        PackageManager packageManager = mockPackageManagerWithThreeDSecureWebViewActivity();
         Context context = spy(RuntimeEnvironment.application);
         when(context.getPackageManager()).thenReturn(packageManager);
         mActivity.context = context;
-        mActivity.dropInRequest = new DropInRequest()
+        mActivity.setDropInRequest(new DropInRequest()
                 .tokenizationKey(TOKENIZATION_KEY)
                 .amount("1.00")
-                .requestThreeDSecureVerification(true);
+                .requestThreeDSecureVerification(true));
         BraintreeUnitTestHttpClient httpClient = new BraintreeUnitTestHttpClient()
                 .configuration(new TestConfigurationBuilder()
                         .creditCards(getSupportedCardConfiguration())
@@ -737,9 +735,9 @@ public class AddCardActivityUnitTest {
     }
 
     private void setupViews() {
-        mAddCardView = (AddCardView) mActivity.findViewById(R.id.bt_add_card_view);
-        mEditCardView = (EditCardView) mActivity.findViewById(R.id.bt_edit_card_view);
-        mEnrollmentCardView = (EnrollmentCardView) mActivity.findViewById(R.id.bt_enrollment_card_view);
+        mAddCardView = mActivity.findViewById(R.id.bt_add_card_view);
+        mEditCardView = mActivity.findViewById(R.id.bt_edit_card_view);
+        mEnrollmentCardView = mActivity.findViewById(R.id.bt_enrollment_card_view);
     }
 
     private static void setText(View view, int id, String text) {
@@ -782,18 +780,5 @@ public class AddCardActivityUnitTest {
                 .supportedCardTypes(PaymentMethodType.VISA.getCanonicalName(),
                         PaymentMethodType.AMEX.getCanonicalName(),
                         PaymentMethodType.UNIONPAY.getCanonicalName());
-    }
-
-    private PackageManager mockPackageManager() throws PackageManager.NameNotFoundException {
-        ActivityInfo activityInfo = new ActivityInfo();
-        activityInfo.name = "com.braintreepayments.api.threedsecure.ThreeDSecureWebViewActivity";
-        PackageInfo packageInfo = new PackageInfo();
-        packageInfo.activities = new ActivityInfo[] { activityInfo };
-
-        PackageManager packageManager = spy(RuntimeEnvironment.application.getPackageManager());
-        doReturn(packageInfo).when(packageManager)
-                .getPackageInfo("com.braintreepayments.api.dropin", PackageManager.GET_ACTIVITIES);
-
-        return packageManager;
     }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardUnitTestActivity.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardUnitTestActivity.java
@@ -15,7 +15,6 @@ import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KE
 public class AddCardUnitTestActivity extends AddCardActivity {
 
     public Context context;
-    public DropInRequest dropInRequest;
     public BraintreeFragment braintreeFragment;
     public BraintreeUnitTestHttpClient httpClient;
 
@@ -23,12 +22,12 @@ public class AddCardUnitTestActivity extends AddCardActivity {
     public void onCreate(Bundle savedInstanceState) {
         setTheme(R.style.bt_add_card_activity_theme);
 
-        if (dropInRequest == null) {
-            dropInRequest = new DropInRequest().tokenizationKey(TOKENIZATION_KEY);
+        if (mDropInRequest == null) {
+            mDropInRequest = new DropInRequest().tokenizationKey(TOKENIZATION_KEY);
         }
 
         Intent intent = new Intent()
-                .putExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST, dropInRequest);
+                .putExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST, mDropInRequest);
         setIntent(intent);
 
         super.onCreate(savedInstanceState);
@@ -37,6 +36,10 @@ public class AddCardUnitTestActivity extends AddCardActivity {
             ConfigurationManagerTestUtils.setFetchingConfiguration(false);
             waitForConfiguration(braintreeFragment, this);
         }
+    }
+
+    public void setDropInRequest(DropInRequest dropInRequest) {
+        mDropInRequest = dropInRequest;
     }
 
     @Override

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
@@ -1,0 +1,143 @@
+package com.braintreepayments.api.dropin;
+
+import android.content.Intent;
+
+import com.braintreepayments.api.exceptions.InvalidArgumentException;
+import com.braintreepayments.api.test.TestConfigurationBuilder;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+
+import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KEY;
+import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class BaseActivityUnitTest {
+
+    private ActivityController mActivityController;
+    private BaseActivity mActivity;
+
+    @Test
+    public void onCreate_setsDropInRequest() {
+        Intent intent = new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .getIntent(RuntimeEnvironment.application);
+        mActivityController = Robolectric.buildActivity(BaseActivity.class, intent);
+        mActivity = (BaseActivity) mActivityController.get();
+
+        assertNull(mActivity.mDropInRequest);
+
+        mActivityController.create();
+
+        assertNotNull(mActivity.mDropInRequest);
+        assertEquals(TOKENIZATION_KEY, mActivity.mDropInRequest.getAuthorization());
+    }
+
+    @Test
+    public void getBraintreeFragment_returnsABraintreeFragment() throws InvalidArgumentException {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .getIntent(RuntimeEnvironment.application));
+
+        assertNotNull(mActivity.getBraintreeFragment());
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void getBraintreeFragment_throwsAnExceptionForEmptyAuthorization() throws InvalidArgumentException {
+        setup(new DropInRequest().getIntent(RuntimeEnvironment.application));
+
+        mActivity.getBraintreeFragment();
+    }
+
+    @Test
+    public void getBraintreeFragment_setsClientTokenPresentWhenAClientTokenIsPresent() throws InvalidArgumentException {
+        setup(new DropInRequest()
+                .clientToken(stringFromFixture("client_token.json"))
+                .getIntent(RuntimeEnvironment.application));
+
+        mActivity.getBraintreeFragment();
+
+        assertTrue(mActivity.mClientTokenPresent);
+    }
+
+    @Test
+    public void getBraintreeFragment_setsClientTokenPresentWhenAClientTokenIsNotPresent() throws InvalidArgumentException {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .getIntent(RuntimeEnvironment.application));
+
+        mActivity.getBraintreeFragment();
+
+        assertFalse(mActivity.mClientTokenPresent);
+    }
+
+    @Test
+    public void shouldRequestThreeDSecureVerification_returnsTrueWhenConditionsAreMet() {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .amount("1.00")
+                .requestThreeDSecureVerification(true)
+                .getIntent(RuntimeEnvironment.application));
+        mActivity.mConfiguration = new TestConfigurationBuilder()
+                .threeDSecureEnabled(true)
+                .buildConfiguration();
+
+        assertTrue(mActivity.shouldRequestThreeDSecureVerification());
+    }
+
+    @Test
+    public void shouldRequestThreeDSecureVerification_returnsFalseWhenNotEnabledInDropInRequest() {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .amount("1.00")
+                .requestThreeDSecureVerification(false)
+                .getIntent(RuntimeEnvironment.application));
+        mActivity.mConfiguration = new TestConfigurationBuilder()
+                .threeDSecureEnabled(true)
+                .buildConfiguration();
+
+        assertFalse(mActivity.shouldRequestThreeDSecureVerification());
+    }
+
+    @Test
+    public void shouldRequestThreeDSecureVerification_returnsFalseWhenNoAmountSpecified() {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .requestThreeDSecureVerification(true)
+                .getIntent(RuntimeEnvironment.application));
+        mActivity.mConfiguration = new TestConfigurationBuilder()
+                .threeDSecureEnabled(true)
+                .buildConfiguration();
+
+        assertFalse(mActivity.shouldRequestThreeDSecureVerification());
+    }
+
+    @Test
+    public void shouldRequestThreeDSecureVerification_returnsFalseWhenThreeDSecureIsNotEnabled() {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .amount("1.00")
+                .requestThreeDSecureVerification(true)
+                .getIntent(RuntimeEnvironment.application));
+        mActivity.mConfiguration = new TestConfigurationBuilder()
+                .threeDSecureEnabled(false)
+                .buildConfiguration();
+
+        assertFalse(mActivity.shouldRequestThreeDSecureVerification());
+    }
+
+    public void setup(Intent intent) {
+        mActivityController = Robolectric.buildActivity(BaseActivity.class, intent)
+                .create();
+        mActivity = (BaseActivity) mActivityController.get();
+    }
+}

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/BraintreeUnitTestHttpClient.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/BraintreeUnitTestHttpClient.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 public class BraintreeUnitTestHttpClient extends BraintreeHttpClient {
 
-    public static final String GET_PAYMENT_METHODS = "/v1/payment_methods.*";
+    public static final String GET_PAYMENT_METHODS = "/v1/payment_methods\\?default_first.*";
     public static final String TOKENIZE_CREDIT_CARD = "/v1/payment_methods/" + new CardBuilder().getApiPath();
     public static final String UNIONPAY_CAPABILITIES_PATH = "/v1/payment_methods/credit_cards/capabilities.*";
     public static final String UNIONPAY_ENROLLMENT_PATH = "/v1/union_pay_enrollments";

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -96,7 +96,7 @@ public class DropInActivityUnitTest {
         Exception exception = (Exception) mShadowActivity.getResultIntent()
                 .getSerializableExtra(DropInActivity.EXTRA_ERROR);
         assertTrue(exception instanceof InvalidArgumentException);
-        assertEquals("A client token or client key must be specified in the DropInRequest",
+        assertEquals("A client token or tokenization key must be specified in the DropInRequest",
                 exception.getMessage());
     }
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInUnitTestActivity.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInUnitTestActivity.java
@@ -21,6 +21,8 @@ public class DropInUnitTestActivity extends DropInActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        setTheme(R.style.bt_drop_in_activity_theme);
+
         if (mDropInRequest == null) {
             mDropInRequest = new DropInRequest().tokenizationKey(TOKENIZATION_KEY);
         }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInUnitTestActivity.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInUnitTestActivity.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api.dropin;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 public class DropInUnitTestActivity extends DropInActivity {
 
+    public Context context;
     public BraintreeFragment braintreeFragment;
     public BraintreeUnitTestHttpClient httpClient;
 
@@ -62,5 +64,14 @@ public class DropInUnitTestActivity extends DropInActivity {
         when(resources.getInteger(android.R.integer.config_mediumAnimTime)).thenReturn(0);
         when(resources.getInteger(android.R.integer.config_shortAnimTime)).thenReturn(0);
         return resources;
+    }
+
+    @Override
+    public Context getApplicationContext() {
+        if (context != null) {
+            return context;
+        }
+
+        return super.getApplicationContext();
     }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/test/PackageManagerUtils.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/test/PackageManagerUtils.java
@@ -1,0 +1,27 @@
+package com.braintreepayments.api.test;
+
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import org.robolectric.RuntimeEnvironment;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class PackageManagerUtils {
+
+    public static PackageManager mockPackageManagerWithThreeDSecureWebViewActivity()
+            throws PackageManager.NameNotFoundException {
+        ActivityInfo activityInfo = new ActivityInfo();
+        activityInfo.name = "com.braintreepayments.api.threedsecure.ThreeDSecureWebViewActivity";
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.activities = new ActivityInfo[] { activityInfo };
+
+        PackageManager packageManager = spy(RuntimeEnvironment.application.getPackageManager());
+        doReturn(packageInfo).when(packageManager)
+                .getPackageInfo("com.braintreepayments.api.dropin", PackageManager.GET_ACTIVITIES);
+
+        return packageManager;
+    }
+}


### PR DESCRIPTION
The second half of fixes for #41. 

This change runs 3D Secure verifications on vaulted cards when 3D Secure is requested and enabled ensuring that all cards returned by Drop-in have run through a 3D Secure verification.