### PR TITLE
Enable input masking in AddCardActivity

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -58,6 +58,10 @@ android {
     }
 }
 
+configurations.all {
+    resolutionStrategy.force 'com.android.support:support-compat:27.0.0'
+}
+
 dependencies {
     compile 'com.android.support:support-v4:27.0.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -125,6 +125,8 @@ public class MainActivity extends BaseActivity implements PaymentMethodNonceCrea
                 .requestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this))
                 .collectDeviceData(Settings.shouldCollectDeviceData(this))
                 .googlePaymentRequest(getGooglePaymentRequest())
+                .maskCardNumber(true)
+                .maskSecurityCode(true)
                 .androidPayCart(getAndroidPayCart())
                 .androidPayShippingAddressRequired(Settings.isAndroidPayShippingAddressRequired(this))
                 .androidPayPhoneNumberRequired(Settings.isAndroidPayPhoneNumberRequired(this))

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -53,7 +53,7 @@ android.buildTypes.debug { type ->
 
 dependencies {
     compile 'com.braintreepayments.api:braintree:2.10.0'
-    compile 'com.braintreepayments:card-form:3.2.0'
+    compile 'com.braintreepayments:card-form:3.2.1-SNAPSHOT'
     compile 'com.android.support:cardview-v7:27.0.0'
     compile 'com.google.android.gms:play-services-wallet:11.4.0'
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -53,7 +53,7 @@ android.buildTypes.debug { type ->
 
 dependencies {
     compile 'com.braintreepayments.api:braintree:2.10.0'
-    compile 'com.braintreepayments:card-form:3.2.1-SNAPSHOT'
+    compile 'com.braintreepayments:card-form:3.3.0'
     compile 'com.android.support:cardview-v7:27.0.0'
     compile 'com.google.android.gms:play-services-wallet:11.4.0'
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
@@ -106,6 +106,10 @@ public class AddCardActivity extends BaseActivity implements ConfigurationListen
             mState = CARD_ENTRY;
         }
 
+        mAddCardView.getCardForm().maskedCardNumber(mDropInRequest.shouldMaskCardNumber());
+        mEditCardView.getCardForm().maskedCardNumber(mDropInRequest.shouldMaskCardNumber());
+        mEditCardView.getCardForm().maskedCvv(mDropInRequest.shouldMaskSecurityCode());
+
         enterState(LOADING);
 
         try {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/AddCardActivity.java
@@ -106,9 +106,9 @@ public class AddCardActivity extends BaseActivity implements ConfigurationListen
             mState = CARD_ENTRY;
         }
 
-        mAddCardView.getCardForm().maskedCardNumber(mDropInRequest.shouldMaskCardNumber());
-        mEditCardView.getCardForm().maskedCardNumber(mDropInRequest.shouldMaskCardNumber());
-        mEditCardView.getCardForm().maskedCvv(mDropInRequest.shouldMaskSecurityCode());
+        mAddCardView.getCardForm().maskCardNumber(mDropInRequest.shouldMaskCardNumber());
+        mEditCardView.getCardForm().maskCardNumber(mDropInRequest.shouldMaskCardNumber());
+        mEditCardView.getCardForm().maskCvv(mDropInRequest.shouldMaskSecurityCode());
 
         enterState(LOADING);
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -33,6 +33,8 @@ public class DropInRequest implements Parcelable {
     private boolean mAndroidPayPhoneNumberRequired;
     private boolean mAndroidPayEnabled = true;
     private boolean mGooglePaymentEnabled = true;
+    private boolean mMaskCardNumber = false;
+    private boolean mMaskSecurityCode = false;
     private ArrayList<CountrySpecification> mAndroidAllowedCountriesForShipping = new ArrayList<>();
 
     private List<String> mPayPalAdditionalScopes;
@@ -222,6 +224,24 @@ public class DropInRequest implements Parcelable {
     }
 
     /**
+     * @param maskCardNumber {@code true} to mask the card number when the field is not focused.
+     * See {@link com.braintreepayments.cardform.view.CardEditText} for more details. Defaults to
+     * {@code false}.
+     */
+    public DropInRequest maskCardNumber(boolean maskCardNumber) {
+        mMaskCardNumber = maskCardNumber;
+        return this;
+    }
+
+    /**
+     * @param maskSecurityCode {@code true} to mask the security code during input. Defaults to {@code false}.
+     */
+    public DropInRequest maskSecurityCode(boolean maskSecurityCode) {
+        mMaskSecurityCode = maskSecurityCode;
+        return this;
+    }
+
+    /**
      * Get an {@link Intent} that can be used in {@link android.app.Activity#startActivityForResult(Intent, int)}
      * to launch {@link DropInActivity} and the Drop-in UI.
      *
@@ -289,6 +309,14 @@ public class DropInRequest implements Parcelable {
         return mRequestThreeDSecureVerification;
     }
 
+    boolean shouldMaskCardNumber() {
+        return mMaskCardNumber;
+    }
+
+    boolean shouldMaskSecurityCode() {
+        return mMaskSecurityCode;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -315,6 +343,8 @@ public class DropInRequest implements Parcelable {
         dest.writeByte(mPayPalEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mVenmoEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mRequestThreeDSecureVerification ? (byte) 1 : (byte) 0);
+        dest.writeByte(mMaskCardNumber ? (byte) 1 : (byte) 0);
+        dest.writeByte(mMaskSecurityCode ? (byte) 1 : (byte) 0);
     }
 
     protected DropInRequest(Parcel in) {
@@ -336,6 +366,8 @@ public class DropInRequest implements Parcelable {
         mPayPalEnabled = in.readByte() != 0;
         mVenmoEnabled = in.readByte() != 0;
         mRequestThreeDSecureVerification = in.readByte() != 0;
+        mMaskCardNumber = in.readByte() != 0;
+        mMaskSecurityCode = in.readByte() != 0;
     }
 
     public static final Creator<DropInRequest> CREATOR = new Creator<DropInRequest>() {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
+import android.text.Editable;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -87,6 +88,14 @@ public class EditCardView extends LinearLayout implements OnCardFormFieldFocused
 
     public void setCardNumber(String cardNumber) {
         mCardForm.getCardEditText().setText(cardNumber);
+    }
+
+    public void setMaskCardNumber(boolean mask) {
+        mCardForm.maskedCardNumber(mask);
+    }
+
+    public void setMaskCvv(boolean mask) {
+        mCardForm.maskedCvv(mask);
     }
 
     public void setErrors(ErrorWithResponse errors) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/EditCardView.java
@@ -91,11 +91,11 @@ public class EditCardView extends LinearLayout implements OnCardFormFieldFocused
     }
 
     public void setMaskCardNumber(boolean mask) {
-        mCardForm.maskedCardNumber(mask);
+        mCardForm.maskCardNumber(mask);
     }
 
     public void setMaskCvv(boolean mask) {
-        mCardForm.maskedCvv(mask);
+        mCardForm.maskCvv(mask);
     }
 
     public void setErrors(ErrorWithResponse errors) {

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
@@ -54,6 +54,8 @@ public class DropInRequestUnitTest {
                 .disablePayPal()
                 .disableVenmo()
                 .requestThreeDSecureVerification(true)
+                .maskCardNumber(true)
+                .maskSecurityCode(true)
                 .getIntent(RuntimeEnvironment.application);
 
         DropInRequest dropInRequest = intent.getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
@@ -77,6 +79,8 @@ public class DropInRequestUnitTest {
         assertFalse(dropInRequest.isPayPalEnabled());
         assertFalse(dropInRequest.isVenmoEnabled());
         assertTrue(dropInRequest.shouldRequestThreeDSecureVerification());
+        assertTrue(dropInRequest.shouldMaskCardNumber());
+        assertTrue(dropInRequest.shouldMaskSecurityCode());
     }
 
     @Test
@@ -100,6 +104,8 @@ public class DropInRequestUnitTest {
         assertTrue(dropInRequest.isPayPalEnabled());
         assertTrue(dropInRequest.isVenmoEnabled());
         assertFalse(dropInRequest.shouldRequestThreeDSecureVerification());
+        assertFalse(dropInRequest.shouldMaskCardNumber());
+        assertFalse(dropInRequest.shouldMaskSecurityCode());
     }
 
     @Test
@@ -129,7 +135,9 @@ public class DropInRequestUnitTest {
                 .paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS))
                 .disablePayPal()
                 .disableVenmo()
-                .requestThreeDSecureVerification(true);
+                .requestThreeDSecureVerification(true)
+                .maskCardNumber(true)
+                .maskSecurityCode(true);
 
         Parcel parcel = Parcel.obtain();
         dropInRequest.writeToParcel(parcel, 0);
@@ -154,6 +162,8 @@ public class DropInRequestUnitTest {
         assertFalse(parceledDropInRequest.isPayPalEnabled());
         assertFalse(parceledDropInRequest.isVenmoEnabled());
         assertTrue(parceledDropInRequest.shouldRequestThreeDSecureVerification());
+        assertTrue(parceledDropInRequest.shouldMaskCardNumber());
+        assertTrue(parceledDropInRequest.shouldMaskSecurityCode());
     }
 
     @Test


### PR DESCRIPTION
* Updates `android-card-form` to `3.2.1-SNAPSHOT` (Change to `3.3.0` when [this PR](https://github.com/braintree/android-card-form/pull/36) is merged and released).
* Adds fields in `DropInRequest` to opt-in to masking card and security code input.