### PR TITLE
Add paypal checkout flow

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -232,9 +232,9 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
                     paypalRequest = new PayPalRequest();
                 }
                 if (paypalRequest.getAmount() != null) {
-                    PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                    PayPal.requestOneTimePayment(mBraintreeFragment, paypalRequest);
                 } else {
-                    PayPal.requestBillingAgreement(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                    PayPal.requestBillingAgreement(mBraintreeFragment, paypalRequest);
                 }
                 break;
             case ANDROID_PAY:
@@ -360,8 +360,7 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
         if (listener != null) {
             slideOutAnimation.setAnimationListener(new AnimationListener() {
                 @Override
-                public void onAnimationStart(Animation animation) {
-                }
+                public void onAnimationStart(Animation animation) {}
 
                 @Override
                 public void onAnimationEnd(Animation animation) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -228,7 +228,11 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
         switch (type) {
             case PAYPAL:
                 if(mDropInRequest.getPayPalRequest() != null) {
-                    PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                    if(mDropInRequest.getPayPalRequest().getAmount() != null) {
+                        PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                    } else {
+                        PayPal.requestBillingAgreement(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                    }
                 } else {
                     PayPalRequest payPalRequest = new PayPalRequest();
                     PayPal.requestBillingAgreement(mBraintreeFragment, payPalRequest);

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -227,15 +227,14 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
 
         switch (type) {
             case PAYPAL:
-                if(mDropInRequest.getPayPalRequest() != null) {
-                    if(mDropInRequest.getPayPalRequest().getAmount() != null) {
-                        PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
-                    } else {
-                        PayPal.requestBillingAgreement(mBraintreeFragment, mDropInRequest.getPayPalRequest());
-                    }
+                PayPalRequest paypalRequest = mDropInRequest.getPayPalRequest();
+                if (paypalRequest == null) {
+                    paypalRequest = new PayPalRequest();
+                }
+                if (paypalRequest.getAmount() != null) {
+                    PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
                 } else {
-                    PayPalRequest payPalRequest = new PayPalRequest();
-                    PayPal.requestBillingAgreement(mBraintreeFragment, payPalRequest);
+                    PayPal.requestBillingAgreement(mBraintreeFragment, mDropInRequest.getPayPalRequest());
                 }
                 break;
             case ANDROID_PAY:
@@ -361,7 +360,8 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
         if (listener != null) {
             slideOutAnimation.setAnimationListener(new AnimationListener() {
                 @Override
-                public void onAnimationStart(Animation animation) {}
+                public void onAnimationStart(Animation animation) {
+                }
 
                 @Override
                 public void onAnimationEnd(Animation animation) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -45,6 +45,7 @@ import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
 import com.braintreepayments.api.models.CardNonce;
 import com.braintreepayments.api.models.Configuration;
+import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 
 import java.util.List;
@@ -226,7 +227,12 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
 
         switch (type) {
             case PAYPAL:
-                PayPal.authorizeAccount(mBraintreeFragment);
+                if(mDropInRequest.getPayPalRequest() != null) {
+                    PayPal.requestOneTimePayment(mBraintreeFragment, mDropInRequest.getPayPalRequest());
+                } else {
+                    PayPalRequest payPalRequest = new PayPalRequest();
+                    PayPal.requestBillingAgreement(mBraintreeFragment, payPalRequest);
+                }
                 break;
             case ANDROID_PAY:
                 AndroidPay.requestAndroidPay(mBraintreeFragment, mDropInRequest.getAndroidPayCart(),

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -105,9 +105,9 @@ public class DropInRequest implements Parcelable {
     /**
      * This method is optional.
      *
-     * @param request The PayPal Request {@link PayPalRequest} for the transaction.  If not set or passed
-     *                with no amount, PayPal will default to the billing agreement (Vault) flow.  If
-     *                passed with an amount, PayPal will follow the one time payment (Checkout) flow.
+     * @param request The PayPal Request {@link PayPalRequest} for the transaction.
+     * If not set or passed with no amount, PayPal will default to the billing agreement (Vault) flow.
+     * If passed with an amount, PayPal will follow the one time payment (Checkout) flow.
      */
     public DropInRequest paypalRequest(PayPalRequest request) {
         mPayPalRequest = request;

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -106,8 +106,8 @@ public class DropInRequest implements Parcelable {
      * This method is optional.
      *
      * @param request The PayPal Request {@link PayPalRequest} for the transaction.
-     * If not set or passed with no amount, PayPal will default to the billing agreement (Vault) flow.
-     * If passed with an amount, PayPal will follow the one time payment (Checkout) flow.
+     * If no amount is set, PayPal will default to the billing agreement (Vault) flow.
+     * If amount is set, PayPal will follow the one time payment (Checkout) flow.
      */
     public DropInRequest paypalRequest(PayPalRequest request) {
         mPayPalRequest = request;

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -105,7 +105,9 @@ public class DropInRequest implements Parcelable {
     /**
      * This method is optional.
      *
-     * @param request The PayPal Request {@link PayPalRequest} for the transaction.
+     * @param request The PayPal Request {@link PayPalRequest} for the transaction.  If not set or passed
+     *                with no amount, PayPal will default to the billing agreement (Vault) flow.  If
+     *                passed with an amount, PayPal will follow the one time payment (Checkout) flow.
      */
     public DropInRequest paypalRequest(PayPalRequest request) {
         mPayPalRequest = request;

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -7,6 +7,7 @@ import android.os.Parcelable;
 
 import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.PayPal;
+import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.GooglePaymentRequest;
 import com.google.android.gms.identity.intents.model.CountrySpecification;
 import com.google.android.gms.wallet.Cart;
@@ -29,6 +30,7 @@ public class DropInRequest implements Parcelable {
 
     private Cart mAndroidPayCart;
     private GooglePaymentRequest mGooglePaymentRequest;
+    private PayPalRequest mPayPalRequest;
     private boolean mAndroidPayShippingAddressRequired;
     private boolean mAndroidPayPhoneNumberRequired;
     private boolean mAndroidPayEnabled = true;
@@ -97,6 +99,16 @@ public class DropInRequest implements Parcelable {
      */
     public DropInRequest googlePaymentRequest(GooglePaymentRequest request) {
         mGooglePaymentRequest = request;
+        return this;
+    }
+
+    /**
+     * This method is optional.
+     *
+     * @param request The PayPal Request {@link PayPalRequest} for the transaction.
+     */
+    public DropInRequest paypalRequest(PayPalRequest request) {
+        mPayPalRequest = request;
         return this;
     }
 
@@ -293,6 +305,8 @@ public class DropInRequest implements Parcelable {
         return mPayPalEnabled;
     }
 
+    public PayPalRequest getPayPalRequest() { return mPayPalRequest; }
+
     public boolean isVenmoEnabled() {
         return mVenmoEnabled;
     }
@@ -339,6 +353,7 @@ public class DropInRequest implements Parcelable {
         dest.writeParcelable(mGooglePaymentRequest, 0);
         dest.writeByte(mGooglePaymentEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mAndroidPayEnabled ? (byte) 1 : (byte) 0);
+        dest.writeParcelable(mPayPalRequest, 0);
         dest.writeStringList(mPayPalAdditionalScopes);
         dest.writeByte(mPayPalEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mVenmoEnabled ? (byte) 1 : (byte) 0);
@@ -362,6 +377,7 @@ public class DropInRequest implements Parcelable {
         mGooglePaymentRequest = in.readParcelable(GooglePaymentRequest.class.getClassLoader());
         mGooglePaymentEnabled = in.readByte() != 0;
         mAndroidPayEnabled = in.readByte() != 0;
+        mPayPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
         mPayPalAdditionalScopes = in.createStringArrayList();
         mPayPalEnabled = in.readByte() != 0;
         mVenmoEnabled = in.readByte() != 0;

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
@@ -98,8 +98,42 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPal() {
+    public void onPaymentMethodSelected_startsPayPalRequestBillingAgreement() {
         DropInRequest dropInRequest = new DropInRequest();
+        mActivity.setDropInRequest(dropInRequest);
+        mockStatic(PayPal.class);
+        doNothing().when(PayPal.class);
+        PayPal.requestBillingAgreement(any(BraintreeFragment.class), any(PayPalRequest.class));
+
+        mActivity.onPaymentMethodSelected(PaymentMethodType.PAYPAL);
+
+        verifyStatic();
+        PayPal.requestBillingAgreement(eq(mActivity.braintreeFragment), any(PayPalRequest.class));
+    }
+
+    @Test
+    public void onPaymentMethodSelected_startsPayPalRequestOneTimePayment() {
+        PayPalRequest paypalRequest = new PayPalRequest("10")
+                .currencyCode("USD");
+        DropInRequest dropInRequest = new DropInRequest()
+                .paypalRequest(paypalRequest);
+        mActivity.setDropInRequest(dropInRequest);
+        mockStatic(PayPal.class);
+        doNothing().when(PayPal.class);
+        PayPal.requestOneTimePayment(any(BraintreeFragment.class), any(PayPalRequest.class));
+
+        mActivity.onPaymentMethodSelected(PaymentMethodType.PAYPAL);
+
+        verifyStatic();
+        PayPal.requestOneTimePayment(eq(mActivity.braintreeFragment), any(PayPalRequest.class));
+    }
+
+    @Test
+    public void onPaymentMethodSelected_startsPayPalWIthRequestDefaultsToBillingAgreement() {
+        PayPalRequest paypalRequest = new PayPalRequest()
+                .billingAgreementDescription("Peter Pipers Pepper Pickers");
+        DropInRequest dropInRequest = new DropInRequest()
+                .paypalRequest(paypalRequest);
         mActivity.setDropInRequest(dropInRequest);
         mockStatic(PayPal.class);
         doNothing().when(PayPal.class);

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
@@ -12,6 +12,7 @@ import com.braintreepayments.api.dropin.utils.PaymentMethodType;
 import com.braintreepayments.api.exceptions.GoogleApiClientException;
 import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 import com.braintreepayments.api.models.Configuration;
+import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.test.TestConfigurationBuilder;
 import com.google.android.gms.wallet.Cart;
 
@@ -38,6 +39,7 @@ import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -97,14 +99,16 @@ public class DropInActivityPowerMockTest {
 
     @Test
     public void onPaymentMethodSelected_startsPayPal() {
+        DropInRequest dropInRequest = new DropInRequest();
+        mActivity.setDropInRequest(dropInRequest);
         mockStatic(PayPal.class);
         doNothing().when(PayPal.class);
-        PayPal.authorizeAccount(any(BraintreeFragment.class));
+        PayPal.requestBillingAgreement(any(BraintreeFragment.class), any(PayPalRequest.class));
 
         mActivity.onPaymentMethodSelected(PaymentMethodType.PAYPAL);
 
         verifyStatic();
-        PayPal.authorizeAccount(mActivity.braintreeFragment);
+        PayPal.requestBillingAgreement(eq(mActivity.braintreeFragment), any(PayPalRequest.class));
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
@@ -98,7 +98,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalRequestBillingAgreementByDefault() {
+    public void onPaymentMethodSelected_withoutPayPalRequest_startsRequestBillingAgreement() {
         DropInRequest dropInRequest = new DropInRequest();
         mActivity.setDropInRequest(dropInRequest);
         mockStatic(PayPal.class);
@@ -112,7 +112,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalRequestWithAmountUsesOneTimePayment() {
+    public void onPaymentMethodSelected_withPayPalRequestAndAmount_startsRequestOneTimePayment() {
         PayPalRequest paypalRequest = new PayPalRequest("10")
                 .currencyCode("USD");
         DropInRequest dropInRequest = new DropInRequest()
@@ -129,7 +129,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalWIthRequestWithoutAmountUsesBillingAgreement() {
+    public void onPaymentMethodSelected_withPayPalRequestWithoutAmount_startsRequestBillingAgreement() {
         PayPalRequest paypalRequest = new PayPalRequest()
                 .billingAgreementDescription("Peter Pipers Pepper Pickers");
         DropInRequest dropInRequest = new DropInRequest()

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityPowerMockTest.java
@@ -98,7 +98,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalRequestBillingAgreement() {
+    public void onPaymentMethodSelected_startsPayPalRequestBillingAgreementByDefault() {
         DropInRequest dropInRequest = new DropInRequest();
         mActivity.setDropInRequest(dropInRequest);
         mockStatic(PayPal.class);
@@ -112,7 +112,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalRequestOneTimePayment() {
+    public void onPaymentMethodSelected_startsPayPalRequestWithAmountUsesOneTimePayment() {
         PayPalRequest paypalRequest = new PayPalRequest("10")
                 .currencyCode("USD");
         DropInRequest dropInRequest = new DropInRequest()
@@ -129,7 +129,7 @@ public class DropInActivityPowerMockTest {
     }
 
     @Test
-    public void onPaymentMethodSelected_startsPayPalWIthRequestDefaultsToBillingAgreement() {
+    public void onPaymentMethodSelected_startsPayPalWIthRequestWithoutAmountUsesBillingAgreement() {
         PayPalRequest paypalRequest = new PayPalRequest()
                 .billingAgreementDescription("Peter Pipers Pepper Pickers");
         DropInRequest dropInRequest = new DropInRequest()

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
@@ -5,6 +5,7 @@ import android.os.Parcel;
 
 import com.braintreepayments.api.PayPal;
 import com.braintreepayments.api.models.GooglePaymentRequest;
+import com.braintreepayments.api.models.PayPalRequest;
 import com.google.android.gms.wallet.Cart;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.WalletConstants;
@@ -39,6 +40,9 @@ public class DropInRequestUnitTest {
                         .build())
                 .emailRequired(true);
 
+        PayPalRequest paypalRequest = new PayPalRequest("10")
+                .currencyCode("USD");
+
         Intent intent = new DropInRequest()
                 .tokenizationKey(TOKENIZATION_KEY)
                 .collectDeviceData(true)
@@ -50,6 +54,7 @@ public class DropInRequestUnitTest {
                 .disableAndroidPay()
                 .googlePaymentRequest(googlePaymentRequest)
                 .disableGooglePayment()
+                .paypalRequest(paypalRequest)
                 .paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS))
                 .disablePayPal()
                 .disableVenmo()
@@ -75,6 +80,8 @@ public class DropInRequestUnitTest {
         assertFalse(dropInRequest.isGooglePaymentEnabled());
         assertEquals(1, dropInRequest.getAndroidPayAllowedCountriesForShipping().size());
         assertEquals("GB", dropInRequest.getAndroidPayAllowedCountriesForShipping().get(0).getCountryCode());
+        assertEquals("10", dropInRequest.getPayPalRequest().getAmount());
+        assertEquals("USD", dropInRequest.getPayPalRequest().getCurrencyCode());
         assertEquals(Collections.singletonList(PayPal.SCOPE_ADDRESS), dropInRequest.getPayPalAdditionalScopes());
         assertFalse(dropInRequest.isPayPalEnabled());
         assertFalse(dropInRequest.isVenmoEnabled());
@@ -101,6 +108,7 @@ public class DropInRequestUnitTest {
         assertTrue(dropInRequest.isGooglePaymentEnabled());
         assertTrue(dropInRequest.getAndroidPayAllowedCountriesForShipping().isEmpty());
         assertNull(dropInRequest.getPayPalAdditionalScopes());
+        assertNull(dropInRequest.getPayPalRequest());
         assertTrue(dropInRequest.isPayPalEnabled());
         assertTrue(dropInRequest.isVenmoEnabled());
         assertFalse(dropInRequest.shouldRequestThreeDSecureVerification());
@@ -121,6 +129,9 @@ public class DropInRequestUnitTest {
                         .build())
                 .emailRequired(true);
 
+        PayPalRequest paypalRequest = new PayPalRequest("10")
+                .currencyCode("USD");
+
         DropInRequest dropInRequest = new DropInRequest()
                 .tokenizationKey(TOKENIZATION_KEY)
                 .collectDeviceData(true)
@@ -132,6 +143,7 @@ public class DropInRequestUnitTest {
                 .disableAndroidPay()
                 .googlePaymentRequest(googlePaymentRequest)
                 .disableGooglePayment()
+                .paypalRequest(paypalRequest)
                 .paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS))
                 .disablePayPal()
                 .disableVenmo()
@@ -157,6 +169,8 @@ public class DropInRequestUnitTest {
         assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPriceStatus());
         assertTrue(dropInRequest.getGooglePaymentRequest().isEmailRequired());
+        assertEquals("10", dropInRequest.getPayPalRequest().getAmount());
+        assertEquals("USD", dropInRequest.getPayPalRequest().getCurrencyCode());
         assertFalse(dropInRequest.isGooglePaymentEnabled());
         assertEquals(Collections.singletonList(PayPal.SCOPE_ADDRESS), parceledDropInRequest.getPayPalAdditionalScopes());
         assertFalse(parceledDropInRequest.isPayPalEnabled());


### PR DESCRIPTION
Allows for a [`PayPalRequest`](https://github.com/braintree/braintree_android/blob/master/Braintree/src/main/java/com/braintreepayments/api/models/PayPalRequest.java) object to be specified for more control over the PayPal flow in Drop-in.

* If a `PayPalRequst` with an `amount` is used, the one time payment (Checkout) flow is used
* If a `PayPalRequest` without an `amount` is used, the billing agreement (Vault) flow is used
* If no `PayPalRequest` is passed, the flow will default to billing agreement (Vault) flow.