### PR TITLE
Test improvements around WebView interaction

### DIFF
--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -18,6 +18,7 @@ import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECUR
 import static com.braintreepayments.demo.test.utilities.CardNumber.UNIONPAY_CREDIT;
 import static com.braintreepayments.demo.test.utilities.CardNumber.UNIONPAY_SMS_NOT_REQUIRED;
 import static com.braintreepayments.demo.test.utilities.CardNumber.VISA;
+import static com.braintreepayments.demo.test.utilities.UiTestActions.clickWebViewText;
 import static com.lukekorth.deviceautomator.AutomatorAction.click;
 import static com.lukekorth.deviceautomator.AutomatorAction.setText;
 import static com.lukekorth.deviceautomator.AutomatorAssertion.text;
@@ -80,7 +81,10 @@ public class DropInTest extends TestHelper {
         onDevice().typeText("1234");
         onDevice().pressTab().pressTab().pressEnter();
 
-        onDevice(withText("Return To App")).waitForExists().waitForEnabled().perform(click());
+        onDevice(withText("Return To App")).waitForExists(1000);
+        if (onDevice(withText("Return To App")).exists()) {
+            clickWebViewText("Return To App");
+        }
 
         getNonceDetails().check(text(containsString("Card Last Two: 02")));
         getNonceDetails().check(text(containsString("3DS isLiabilityShifted: true")));
@@ -170,7 +174,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("PayPal")).perform(click());
-        onDevice(withText("Proceed with Sandbox Purchase")).perform(click());
+        clickWebViewText("Proceed with Sandbox Purchase");
 
         getNonceDetails().check(text(containsString("Email: bt_buyer_us@paypal.com")));
 
@@ -186,7 +190,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("PayPal")).perform(click());
-        onDevice(withText("Proceed with Sandbox Purchase")).perform(click());
+        clickWebViewText("Proceed with Sandbox Purchase");
 
         getNonceDetails().check(text(containsString("Email: bt_buyer_us@paypal.com")));
 

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/UiTestActions.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/UiTestActions.java
@@ -1,0 +1,34 @@
+package com.braintreepayments.demo.test.utilities;
+
+import android.support.test.uiautomator.Configurator;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+
+import static com.lukekorth.deviceautomator.AutomatorAction.click;
+import static com.lukekorth.deviceautomator.DeviceAutomator.onDevice;
+import static com.lukekorth.deviceautomator.UiObjectMatcher.withContentDescription;
+import static com.lukekorth.deviceautomator.UiObjectMatcher.withText;
+
+public class UiTestActions {
+    public static void clickWebViewText(String text) {
+        clickWebViewText(text, 1000);
+    }
+
+    public static void clickWebViewText(String text, Integer waitTimeout) {
+        Configurator configurator = Configurator.getInstance();
+        long originalTimeout = configurator.getWaitForSelectorTimeout();
+
+        configurator.setWaitForSelectorTimeout(waitTimeout);
+
+        try {
+            onDevice(withContentDescription(text)).perform(click());
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof UiObjectNotFoundException) {
+                onDevice(withText(text)).perform(click());
+            } else {
+                throw e;
+            }
+        } finally {
+            configurator.setWaitForSelectorTimeout(originalTimeout);
+        }
+    }
+}


### PR DESCRIPTION
* Text inside of a WebView was not properly getting clicked. Borrowing a method from braintree_android that [clicks on text inside a WebView](https://github.com/braintree/braintree_android/blob/master/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/UiTestActions.java#L17).

* 3DS does return sometimes, but our tests still try to click "Return To App". Fixed it by checking for existence before clicking on the WebView.