### PR TITLE
Add invisible as default visibility to vault manager button

### DIFF
--- a/Drop-In/src/main/res/layout/bt_drop_in_activity.xml
+++ b/Drop-In/src/main/res/layout/bt_drop_in_activity.xml
@@ -69,6 +69,7 @@
                             android:onClick="onVaultEditButtonClick"
                             android:layout_alignParentEnd="true"
                             android:layout_alignParentRight="true"
+                            android:visibility="invisible"
                             android:text="@string/bt_edit"/>
 
                         <TextView

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -41,6 +41,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static com.braintreepayments.api.dropin.DropInActivity.EXTRA_PAYMENT_METHOD_NONCES;
 import static com.braintreepayments.api.dropin.DropInRequest.EXTRA_CHECKOUT_REQUEST;
@@ -768,18 +769,9 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    public void vaultEditButton_whenVaultManagerEnabled_isVisible() {
+    public void onCreate_vaultEditButtonIsInvisible() {
         mActivity.setDropInRequest(new DropInRequest()
-               .vaultManager(true));
-
-        mActivityController.setup();
-
-        assertEquals(View.VISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
-    }
-
-    @Test
-    public void vaultEditButton_whenVaultManagerUnspecified_isInvisible() {
-        mActivity.setDropInRequest(new DropInRequest());
+                .vaultManager(true));
 
         mActivityController.setup();
 
@@ -787,11 +779,45 @@ public class DropInActivityUnitTest {
     }
 
     @Test
+    public void vaultEditButton_whenVaultManagerEnabled_isVisible() {
+        List<PaymentMethodNonce> nonceList = new ArrayList<>();
+        nonceList.add(mock(CardNonce.class));
+
+        mActivity.setDropInRequest(new DropInRequest()
+               .vaultManager(true));
+
+        mActivityController.setup();
+
+        mActivity.onPaymentMethodNoncesUpdated(nonceList);
+
+        assertEquals(View.VISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
+    }
+
+    @Test
+    public void vaultEditButton_whenVaultManagerUnspecified_isInvisible() {
+        List<PaymentMethodNonce> nonceList = new ArrayList<>();
+        nonceList.add(mock(CardNonce.class));
+
+        mActivity.setDropInRequest(new DropInRequest());
+
+        mActivityController.setup();
+
+        mActivity.onPaymentMethodNoncesUpdated(nonceList);
+
+        assertEquals(View.INVISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
+    }
+
+    @Test
     public void vaultEditButton_whenVaultManagerDisabled_isInvisible() {
+        List<PaymentMethodNonce> nonceList = new ArrayList<>();
+        nonceList.add(mock(CardNonce.class));
+
         mActivity.setDropInRequest(new DropInRequest()
                 .vaultManager(false));
 
         mActivityController.setup();
+
+        mActivity.onPaymentMethodNoncesUpdated(nonceList);
 
         assertEquals(View.INVISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.ViewSwitcher;
@@ -764,6 +765,35 @@ public class DropInActivityUnitTest {
         setup(mock(BraintreeFragment.class));
 
         assertExceptionIsReturned("sdk-error", new Exception("Error!"));
+    }
+
+    @Test
+    public void vaultEditButton_whenVaultManagerEnabled_isVisible() {
+        mActivity.setDropInRequest(new DropInRequest()
+               .vaultManager(true));
+
+        mActivityController.setup();
+
+        assertEquals(View.VISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
+    }
+
+    @Test
+    public void vaultEditButton_whenVaultManagerUnspecified_isInvisible() {
+        mActivity.setDropInRequest(new DropInRequest());
+
+        mActivityController.setup();
+
+        assertEquals(View.INVISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
+    }
+
+    @Test
+    public void vaultEditButton_whenVaultManagerDisabled_isInvisible() {
+        mActivity.setDropInRequest(new DropInRequest()
+                .vaultManager(false));
+
+        mActivityController.setup();
+
+        assertEquals(View.INVISIBLE, mActivity.findViewById(R.id.bt_vault_edit_button).getVisibility());
     }
 
     @Test


### PR DESCRIPTION
`DropInActivity` checks to see if `vaultManager` was passed `true` and sets the
`vaultManager` button to visible, but does not set the button to `invisible`
if `false` or nothing was passed.  However, Android views default to visible
which means that the button was always visible.  This sets a default
visibility of invisible which hides the button unless `vaultManager` is
passed with `true`.