### PR TITLE
Deprecate paypalAdditionalScopes

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -133,6 +133,7 @@ public class Settings {
         return getPreferences(context).getString("paypal_payment_type", context.getString(R.string.paypal_billing_agreement));
     }
 
+    @Deprecated
     public static boolean isPayPalAddressScopeRequested(Context context) {
         return getPreferences(context).getBoolean("paypal_request_address_scope", false);
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -40,6 +40,7 @@ public class DropInRequest implements Parcelable {
     private boolean mMaskSecurityCode = false;
     private boolean mVaultManagerEnabled = false;
     private ArrayList<CountrySpecification> mAndroidAllowedCountriesForShipping = new ArrayList<>();
+    @Deprecated
     private List<String> mPayPalAdditionalScopes;
     private boolean mPayPalEnabled = true;
     private boolean mVenmoEnabled = true;
@@ -196,14 +197,10 @@ public class DropInRequest implements Parcelable {
     }
 
     /**
-     * Set additional scopes to request when a user is authorizing PayPal.
-     *
-     * This method is optional.
-     *
-     * @param additionalScopes A {@link java.util.List} of additional scopes.
-     *        Ex: PayPal.SCOPE_ADDRESS.
-     *        Acceptable scopes are defined in {@link PayPal}.
+     * @deprecated Future Payments has been deprecated and this method will be removed in
+     * the next major version.
      */
+    @Deprecated
     public DropInRequest paypalAdditionalScopes(List<String> additionalScopes) {
         mPayPalAdditionalScopes = additionalScopes;
         return this;
@@ -321,6 +318,7 @@ public class DropInRequest implements Parcelable {
         return mAndroidAllowedCountriesForShipping;
     }
 
+    @Deprecated
     List<String> getPayPalAdditionalScopes() {
         return mPayPalAdditionalScopes;
     }


### PR DESCRIPTION
PayPal's Future Payment flow is what used these additional scopes,
which is being deprecated in braintree-android.