### PR TITLE
[4.x] Remove paypalAdditionalScopes

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -135,10 +135,6 @@ public class MainActivity extends BaseActivity implements PaymentMethodNonceCrea
                 .vaultManager(Settings.isVaultManagerEnabled(this))
                 .cardholderNameStatus(Settings.getCardholderNameStatus(this));
 
-        if (Settings.isPayPalAddressScopeRequested(this)) {
-            dropInRequest.paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS));
-        }
-
         startActivityForResult(dropInRequest.getIntent(this), DROP_IN_REQUEST);
     }
 

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -128,15 +128,6 @@ public class Settings {
         return countries;
     }
 
-    public static String getPayPalPaymentType(Context context) {
-        return getPreferences(context).getString("paypal_payment_type", context.getString(R.string.paypal_billing_agreement));
-    }
-
-    @Deprecated
-    public static boolean isPayPalAddressScopeRequested(Context context) {
-        return getPreferences(context).getBoolean("paypal_request_address_scope", false);
-    }
-
     public static boolean isPayPalSignatureVerificationDisabled(Context context) {
         return getPreferences(context).getBoolean("paypal_disable_signature_verification", true);
     }

--- a/Demo/src/main/java/com/braintreepayments/demo/Settings.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/Settings.java
@@ -132,6 +132,7 @@ public class Settings {
         return getPreferences(context).getString("paypal_payment_type", context.getString(R.string.paypal_billing_agreement));
     }
 
+    @Deprecated
     public static boolean isPayPalAddressScopeRequested(Context context) {
         return getPreferences(context).getBoolean("paypal_request_address_scope", false);
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -40,8 +40,6 @@ public class DropInRequest implements Parcelable {
     private boolean mMaskSecurityCode = false;
     private boolean mVaultManagerEnabled = false;
     private ArrayList<CountrySpecification> mAndroidAllowedCountriesForShipping = new ArrayList<>();
-    @Deprecated
-    private List<String> mPayPalAdditionalScopes;
     private boolean mPayPalEnabled = true;
     private boolean mVenmoEnabled = true;
     private int mCardholderNameStatus = CardForm.FIELD_DISABLED;
@@ -197,16 +195,6 @@ public class DropInRequest implements Parcelable {
     }
 
     /**
-     * @deprecated Future Payments has been deprecated and this method will be removed in
-     * the next major version.
-     */
-    @Deprecated
-    public DropInRequest paypalAdditionalScopes(List<String> additionalScopes) {
-        mPayPalAdditionalScopes = additionalScopes;
-        return this;
-    }
-
-    /**
      * Disables PayPal in Drop-in.
      */
     public DropInRequest disablePayPal() {
@@ -318,11 +306,6 @@ public class DropInRequest implements Parcelable {
         return mAndroidAllowedCountriesForShipping;
     }
 
-    @Deprecated
-    List<String> getPayPalAdditionalScopes() {
-        return mPayPalAdditionalScopes;
-    }
-
     public boolean isPayPalEnabled() {
         return mPayPalEnabled;
     }
@@ -382,7 +365,6 @@ public class DropInRequest implements Parcelable {
         dest.writeByte(mGooglePaymentEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mAndroidPayEnabled ? (byte) 1 : (byte) 0);
         dest.writeParcelable(mPayPalRequest, 0);
-        dest.writeStringList(mPayPalAdditionalScopes);
         dest.writeByte(mPayPalEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mVenmoEnabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mRequestThreeDSecureVerification ? (byte) 1 : (byte) 0);
@@ -408,7 +390,6 @@ public class DropInRequest implements Parcelable {
         mGooglePaymentEnabled = in.readByte() != 0;
         mAndroidPayEnabled = in.readByte() != 0;
         mPayPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
-        mPayPalAdditionalScopes = in.createStringArrayList();
         mPayPalEnabled = in.readByte() != 0;
         mVenmoEnabled = in.readByte() != 0;
         mRequestThreeDSecureVerification = in.readByte() != 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -40,6 +40,7 @@ public class DropInRequest implements Parcelable {
     private boolean mMaskSecurityCode = false;
     private boolean mVaultManagerEnabled = false;
     private ArrayList<CountrySpecification> mAndroidAllowedCountriesForShipping = new ArrayList<>();
+    @Deprecated
     private List<String> mPayPalAdditionalScopes;
     private boolean mPayPalEnabled = true;
     private boolean mVenmoEnabled = true;
@@ -196,14 +197,10 @@ public class DropInRequest implements Parcelable {
     }
 
     /**
-     * Set additional scopes to request when a user is authorizing PayPal.
-     *
-     * This method is optional.
-     *
-     * @param additionalScopes A {@link java.util.List} of additional scopes.
-     *        Ex: PayPal.SCOPE_ADDRESS.
-     *        Acceptable scopes are defined in {@link PayPal}.
+     * @deprecated Future Payments has been deprecated and this method will be removed in
+     * the next major version.
      */
+    @Deprecated
     public DropInRequest paypalAdditionalScopes(List<String> additionalScopes) {
         mPayPalAdditionalScopes = additionalScopes;
         return this;
@@ -321,6 +318,7 @@ public class DropInRequest implements Parcelable {
         return mAndroidAllowedCountriesForShipping;
     }
 
+    @Deprecated
     List<String> getPayPalAdditionalScopes() {
         return mPayPalAdditionalScopes;
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInRequestUnitTest.java
@@ -56,7 +56,6 @@ public class DropInRequestUnitTest {
                 .googlePaymentRequest(googlePaymentRequest)
                 .disableGooglePayment()
                 .paypalRequest(paypalRequest)
-                .paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS))
                 .disablePayPal()
                 .disableVenmo()
                 .requestThreeDSecureVerification(true)
@@ -85,7 +84,6 @@ public class DropInRequestUnitTest {
         assertEquals("GB", dropInRequest.getAndroidPayAllowedCountriesForShipping().get(0).getCountryCode());
         assertEquals("10", dropInRequest.getPayPalRequest().getAmount());
         assertEquals("USD", dropInRequest.getPayPalRequest().getCurrencyCode());
-        assertEquals(Collections.singletonList(PayPal.SCOPE_ADDRESS), dropInRequest.getPayPalAdditionalScopes());
         assertFalse(dropInRequest.isPayPalEnabled());
         assertFalse(dropInRequest.isVenmoEnabled());
         assertTrue(dropInRequest.shouldRequestThreeDSecureVerification());
@@ -112,7 +110,6 @@ public class DropInRequestUnitTest {
         assertTrue(dropInRequest.isAndroidPayEnabled());
         assertTrue(dropInRequest.isGooglePaymentEnabled());
         assertTrue(dropInRequest.getAndroidPayAllowedCountriesForShipping().isEmpty());
-        assertNull(dropInRequest.getPayPalAdditionalScopes());
         assertNull(dropInRequest.getPayPalRequest());
         assertTrue(dropInRequest.isPayPalEnabled());
         assertTrue(dropInRequest.isVenmoEnabled());
@@ -151,7 +148,6 @@ public class DropInRequestUnitTest {
                 .googlePaymentRequest(googlePaymentRequest)
                 .disableGooglePayment()
                 .paypalRequest(paypalRequest)
-                .paypalAdditionalScopes(Collections.singletonList(PayPal.SCOPE_ADDRESS))
                 .disablePayPal()
                 .disableVenmo()
                 .requestThreeDSecureVerification(true)
@@ -181,7 +177,6 @@ public class DropInRequestUnitTest {
         assertEquals("10", dropInRequest.getPayPalRequest().getAmount());
         assertEquals("USD", dropInRequest.getPayPalRequest().getCurrencyCode());
         assertFalse(dropInRequest.isGooglePaymentEnabled());
-        assertEquals(Collections.singletonList(PayPal.SCOPE_ADDRESS), parceledDropInRequest.getPayPalAdditionalScopes());
         assertFalse(parceledDropInRequest.isPayPalEnabled());
         assertFalse(parceledDropInRequest.isVenmoEnabled());
         assertTrue(parceledDropInRequest.shouldRequestThreeDSecureVerification());


### PR DESCRIPTION
Removing the deprecated paypalAdditionalScopes in 4.x that was deprecated in #113 