### PR TITLE
Temporary disable UnionPay UI tests

### DIFF
--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -10,9 +10,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.RequiresDevice;
-import androidx.test.filters.SdkSuppress;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECURE_VERIFICATON;

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -7,6 +7,7 @@ import com.braintreepayments.demo.Settings;
 import com.braintreepayments.demo.test.utilities.TestHelper;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -93,6 +94,11 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
+    @Ignore("There is an issue with our merchant account not tokenizing UnionPay. " +
+            "Our merchant account can process capabilities and enrollment but " +
+            "when tokenizing we get a 422 that the merchant account is not setup for credit card " +
+            "processing. " +
+            "Disabling UnionPay tests that involve tokenizing until the issue has been resolved.")
     @Test
     public void tokenizesUnionPay() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));
@@ -117,6 +123,11 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
+    @Ignore("There is an issue with our merchant account not tokenizing UnionPay. " +
+            "Our merchant account can process capabilities and enrollment but " +
+            "when tokenizing we get a 422 that the merchant account is not setup for credit card " +
+            "processing. " +
+            "Disabling UnionPay tests that involve tokenizing until the issue has been resolved.")
     @Test
     public void tokenizesUnionPayWhenEnrollmentIsNotRequired() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));
@@ -139,6 +150,11 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
+    @Ignore("There is an issue with our merchant account not tokenizing UnionPay. " +
+            "Our merchant account can process capabilities and enrollment but " +
+            "when tokenizing we get a 422 that the merchant account is not setup for credit card " +
+            "processing. " +
+            "Disabling UnionPay tests that involve tokenizing until the issue has been resolved.")
     @Test
     public void tokenizesUnionPayWhenFirstSMSCodeIsInvalid() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));


### PR DESCRIPTION
This issue seems to be isolated with our test sandbox/production merchant account.

Our merchant account is enabled for Union Pay and can process capabilities and enrollment. Tokenizing a Union Pay card returns a 422 though.

Disabling the UnionPay UI tests until the issue is resolved.