### PR TITLE
Add analytic events for vaulted card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .bundle
 *.iml
 build
+captures

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -13,6 +13,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.ViewSwitcher;
 
+import com.braintreepayments.api.Card;
 import com.braintreepayments.api.DataCollector;
 import com.braintreepayments.api.GooglePayment;
 import com.braintreepayments.api.PayPal;
@@ -274,12 +275,28 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
         if (paymentMethodNonces.size() > 0) {
             mSupportedPaymentMethodsHeader.setText(R.string.bt_other);
             mVaultedPaymentMethodsContainer.setVisibility(View.VISIBLE);
-            mVaultedPaymentMethodsView.setAdapter(new VaultedPaymentMethodsAdapter(this,
-                    paymentMethodNonces));
+            mVaultedPaymentMethodsView.setAdapter(new VaultedPaymentMethodsAdapter(new PaymentMethodNonceCreatedListener() {
+                @Override
+                public void onPaymentMethodNonceCreated(PaymentMethodNonce paymentMethodNonce) {
+                    if (paymentMethodNonce instanceof CardNonce) {
+                        mBraintreeFragment.sendAnalyticsEvent("vaulted-card.select");
+                    }
+
+                    DropInActivity.this.onPaymentMethodNonceCreated(paymentMethodNonce);
+                }
+            }, paymentMethodNonces));
 
             if (mDropInRequest.isVaultManagerEnabled()) {
                 mVaultManagerButton.setVisibility(View.VISIBLE);
             }
+
+            for (PaymentMethodNonce nonce : paymentMethodNonces) {
+                if (nonce instanceof CardNonce) {
+                    mBraintreeFragment.sendAnalyticsEvent("vaulted-card.appear");
+                    break;
+                }
+            }
+
         } else {
             mSupportedPaymentMethodsHeader.setText(R.string.bt_select_payment_method);
             mVaultedPaymentMethodsContainer.setVisibility(View.GONE);

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/adapters/VaultedPaymentMethodsAdapter.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/adapters/VaultedPaymentMethodsAdapter.java
@@ -23,7 +23,7 @@ public class VaultedPaymentMethodsAdapter extends RecyclerView.Adapter<VaultedPa
     private List<PaymentMethodNonce> mPaymentMethodNonces;
 
     public VaultedPaymentMethodsAdapter(PaymentMethodNonceCreatedListener listener,
-            List<PaymentMethodNonce> paymentMethodNonces) {
+                                        List<PaymentMethodNonce> paymentMethodNonces) {
         mSelectedListener = listener;
         mPaymentMethodNonces = paymentMethodNonces;
     }


### PR DESCRIPTION
We previously collected analytic events for tokenization on new card creation only. This PR adds an analytic event for choosing an already vaulted card.

Events:
- Start event "vaulted-card.appear": when all vaulted cards are shown
- Success event "vaulted-card.select": when a vaulted card is chosen

Notes:
- Will squash after review and before merge.