### PR TITLE
(ISSUE #134) Added super call to onActivityResult in DropInActivity

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -69,8 +69,8 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
      */
     public static final String EXTRA_ERROR = "com.braintreepayments.api.dropin.EXTRA_ERROR";
 
-    private static final int ADD_CARD_REQUEST_CODE = 1;
-    private static final int DELETE_PAYMENT_METHOD_NONCE_CODE = 2;
+    public static final int ADD_CARD_REQUEST_CODE = 1;
+    public static final int DELETE_PAYMENT_METHOD_NONCE_CODE = 2;
     private static final String EXTRA_SHEET_SLIDE_UP_PERFORMED = "com.braintreepayments.api.EXTRA_SHEET_SLIDE_UP_PERFORMED";
     private static final String EXTRA_DEVICE_DATA = "com.braintreepayments.api.EXTRA_DEVICE_DATA";
     static final String EXTRA_PAYMENT_METHOD_NONCES = "com.braintreepayments.api.EXTRA_PAYMENT_METHOD_NONCES";

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -312,29 +312,7 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
 
     @Override
     protected void onActivityResult(int requestCode, final int resultCode, Intent data) {
-        /*
-         * TODO this a temporary work around to fix the Google Payment flow.
-         *
-         * BraintreeFragment starts the GooglePaymentActivity for result to tokenize
-         * Google Payment. GooglePaymentActivity#onActivityResult is called from Google Payment
-         * and a result is set, then the activity finishes.
-         *
-         * What should happen is BraintreeFragment#onActivityResult should be called.
-         *
-         * There seems to be a bug that BraintreeFragment#onActivityResult is bypassed and
-         * DropInActivity#onActivityResult is called, with a random requestCode (79129).
-         * DropInActivity doesn't understand this requestCode so it noops.
-         *
-         * The temporary fix is to forward the data back to BraintreeFragment when we detect
-         * the 79129 requestCode.
-         */
         super.onActivityResult(requestCode, resultCode, data);
-
-        if (requestCode == 79129) {
-            mBraintreeFragment.onActivityResult(BraintreeRequestCodes.GOOGLE_PAYMENT,
-                    resultCode, data);
-            return;
-        }
 
         mLoadingViewSwitcher.setDisplayedChild(0);
         if (resultCode == RESULT_CANCELED) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -40,7 +40,6 @@ import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 import com.braintreepayments.api.interfaces.ConfigurationListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
-import com.braintreepayments.api.models.BraintreeRequestCodes;
 import com.braintreepayments.api.models.CardNonce;
 import com.braintreepayments.api.models.Configuration;
 import com.braintreepayments.api.models.PayPalRequest;
@@ -68,9 +67,9 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
      * {@link #RESULT_CANCELED}.
      */
     public static final String EXTRA_ERROR = "com.braintreepayments.api.dropin.EXTRA_ERROR";
-
     public static final int ADD_CARD_REQUEST_CODE = 1;
     public static final int DELETE_PAYMENT_METHOD_NONCE_CODE = 2;
+
     private static final String EXTRA_SHEET_SLIDE_UP_PERFORMED = "com.braintreepayments.api.EXTRA_SHEET_SLIDE_UP_PERFORMED";
     private static final String EXTRA_DEVICE_DATA = "com.braintreepayments.api.EXTRA_DEVICE_DATA";
     static final String EXTRA_PAYMENT_METHOD_NONCES = "com.braintreepayments.api.EXTRA_PAYMENT_METHOD_NONCES";

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -328,6 +328,8 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
          * The temporary fix is to forward the data back to BraintreeFragment when we detect
          * the 79129 requestCode.
          */
+        super.onActivityResult(requestCode, resultCode, data);
+
         if (requestCode == 79129) {
             mBraintreeFragment.onActivityResult(BraintreeRequestCodes.GOOGLE_PAYMENT,
                     resultCode, data);

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -314,9 +314,10 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
     protected void onActivityResult(int requestCode, final int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        mLoadingViewSwitcher.setDisplayedChild(0);
         if (resultCode == RESULT_CANCELED) {
             if (requestCode == ADD_CARD_REQUEST_CODE) {
+                mLoadingViewSwitcher.setDisplayedChild(0);
+
                 fetchPaymentMethodNonces(true);
             }
 
@@ -324,6 +325,8 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
         } else if (requestCode == ADD_CARD_REQUEST_CODE) {
             final Intent response;
             if (resultCode == RESULT_OK) {
+                mLoadingViewSwitcher.setDisplayedChild(0);
+
                 DropInResult result = data.getParcelableExtra(DropInResult.EXTRA_DROP_IN_RESULT);
                 DropInResult.setLastUsedPaymentMethodType(this, result.getPaymentMethodNonce());
 
@@ -343,6 +346,7 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
             });
         } else if (requestCode == DELETE_PAYMENT_METHOD_NONCE_CODE) {
             if (resultCode == RESULT_OK) {
+                mLoadingViewSwitcher.setDisplayedChild(0);
 
                 if (data != null) {
                     ArrayList<PaymentMethodNonce> paymentMethodNonces = data

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -46,6 +46,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_CANCELED;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_FIRST_USER;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_OK;
+import static com.braintreepayments.api.dropin.DropInActivity.ADD_CARD_REQUEST_CODE;
+import static com.braintreepayments.api.dropin.DropInActivity.DELETE_PAYMENT_METHOD_NONCE_CODE;
 import static com.braintreepayments.api.dropin.DropInActivity.EXTRA_PAYMENT_METHOD_NONCES;
 import static com.braintreepayments.api.dropin.DropInRequest.EXTRA_CHECKOUT_REQUEST;
 import static com.braintreepayments.api.test.PackageManagerUtils.mockPackageManagerSupportsThreeDSecure;
@@ -606,6 +608,40 @@ public class DropInActivityUnitTest {
         assertEquals(0, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
 
         mActivity.onActivityResult(1, RESULT_CANCELED, null);
+
+        assertEquals(1, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
+    }
+
+    @Test
+    public void onActivityResult_successfulAddCardReturnsToApp() throws JSONException {
+        setup(new BraintreeUnitTestHttpClient());
+        assertEquals(0, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
+
+        DropInResult result = new DropInResult()
+                .paymentMethodNonce(CardNonce.fromJson(
+                        stringFromFixture("responses/visa_credit_card_response.json")));
+        Intent data = new Intent()
+                .putExtra(DropInResult.EXTRA_DROP_IN_RESULT, result);
+
+        mActivity.onActivityResult(1, RESULT_OK, data);
+
+        assertEquals(0, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
+    }
+
+    @Test
+    public void onActivityResult_vaultedPaymentEditedReturnsToDropIn() {
+        setup(mock(BraintreeFragment.class));
+
+        PayPalAccountNonce paypalNonce = mock(PayPalAccountNonce.class);
+        when(paypalNonce.getDescription()).thenReturn("paypal-nonce");
+
+        ArrayList<Parcelable> paymentMethodNonces = new ArrayList<Parcelable>();
+        paymentMethodNonces.add(paypalNonce);
+
+        assertEquals(0, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
+
+        mActivity.onActivityResult(DELETE_PAYMENT_METHOD_NONCE_CODE, RESULT_OK, new Intent()
+                .putExtra("com.braintreepayments.api.EXTRA_PAYMENT_METHOD_NONCES", paymentMethodNonces));
 
         assertEquals(1, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -795,34 +795,6 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    /*
-     * TODO this a temporary test for the work around to fix the Google Payment flow.
-     *
-     * BraintreeFragment starts the GooglePaymentActivity for result to tokenize
-     * Google Payment. GooglePaymentActivity#onActivityResult is called from Google Payment
-     * and a result is set, then the activity finishes.
-     *
-     * What should happen is BraintreeFragment#onActivityResult should be called.
-     *
-     * There seems to be a bug that BraintreeFragment#onActivityResult is bypassed and
-     * DropInActivity#onActivityResult is called, with a random requestCode (79129).
-     * DropInActivity doesn't understand this requestCode so it noops.
-     *
-     * The temporary fix is to forward the data back to BraintreeFragment when we detect
-     * the 79129 requestCode.
-     */
-    public void onActivityResult_withRequestCode79129_callsBraintreeFragmentOnActivityResult() {
-        Intent data = new Intent();
-
-        setup(mock(BraintreeFragment.class));
-
-        mActivity.onActivityResult(79129, RESULT_OK, data);
-
-        verify(mActivity.braintreeFragment).onActivityResult(
-                eq(BraintreeRequestCodes.GOOGLE_PAYMENT), eq(RESULT_OK), eq(data));
-    }
-
-    @Test
     public void configurationExceptionExitsActivityWithError() {
         setup(mock(BraintreeFragment.class));
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -623,7 +623,7 @@ public class DropInActivityUnitTest {
         Intent data = new Intent()
                 .putExtra(DropInResult.EXTRA_DROP_IN_RESULT, result);
 
-        mActivity.onActivityResult(1, RESULT_OK, data);
+        mActivity.onActivityResult(ADD_CARD_REQUEST_CODE, RESULT_OK, data);
 
         assertEquals(0, ((ViewSwitcher) mActivity.findViewById(R.id.bt_loading_view_switcher)).getDisplayedChild());
     }


### PR DESCRIPTION
Fix in response to [Issue #134](https://github.com/braintree/braintree-android-drop-in/issues/134) & [Issue #122](https://github.com/braintree/braintree-android-drop-in/issues/122). 

*Problem:* With the PayPal app installed, the drop in would get stuck on an infinite load after app switch back from PayPal. `onActivityResult` was not invoked. This required merchants to call `           super.onActivityResult(requestCode, resultCode, data)` in their `MainActivity.java`'s `onActivityResult` override method.

*Solution:* Add the `super.onActivityResult(requestCode, resultCode, data)` to the `DropInActivity`'s `onActivityResult` method override so merchant doesn't isn't requires to make this call.

Credits:
@xX7

*Note:* Couldn't think of a meaningful test to add for this super call code addition that doesn't already exist in the tests. Any suggestions appreciated.