### PR TITLE
Ignore Proguard warnings from com.nimbusds.jose in Demo App

### DIFF
--- a/Demo/proguard.pro
+++ b/Demo/proguard.pro
@@ -1,7 +1,7 @@
 ## Only Required for Demo App
 
-# Retrofit
 -dontwarn retrofit.**
 -keep class retrofit.** { *; }
 -keepattributes Signature
 -keepattributes Exceptions
+-dontwarn com.nimbusds.jose.**


### PR DESCRIPTION
### Summary of changes

 - Travis CI builds are failing because of proguard warnings in the Demo app from `com.nimbusds.jose.**`. Since we aren't able to fix this issue directly, I'm ignoring the warnings until we have a better solution.

 ### Checklist

 - [ ] ~Added a changelog entry~
