### PR TITLE
Update DropInRequest Amount Docstring

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -71,7 +71,7 @@ public class DropInRequest implements Parcelable {
      * This method is optional. Amount is only used for 3D Secure verifications.
      *
      * This value must be a non-negative number and must match the currency format of the merchant account.
-     * It can only contain numbers and can optionally include one decimal point with exactly 2 decimal place precision (ex: x.xx).
+     * It can only contain numbers and optionally one decimal point with exactly 2 decimal place precision (e.g., x.xx).
      *
      * @param amount Amount of the transaction.
      */

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInRequest.java
@@ -70,8 +70,8 @@ public class DropInRequest implements Parcelable {
      *
      * This method is optional. Amount is only used for 3D Secure verifications.
      *
-     * Amount must be a non-negative number, may optionally contain exactly 2 decimal places
-     * separated by '.', optional thousands separator ',', limited to 7 digits before the decimal point.
+     * This value must be a non-negative number and must match the currency format of the merchant account.
+     * It can only contain numbers and can optionally include one decimal point with exactly 2 decimal place precision (ex: x.xx).
      *
      * @param amount Amount of the transaction.
      */


### PR DESCRIPTION
#### Summary of changes

 - Updated `DropInRequest.amount` docstring to include instructions for merchants to properly format the amount string.
- Solves this [issue](https://github.com/braintree/braintree-android-drop-in/issues/152).

 #### Changelog

Not necessary for this

 #### Questions

- There are processor limits on amount size, but I think it suffices that it live on the docs for `Transaction.sale()`'s `amount` param [here](https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#amount).