### PR TITLE
Bump braintree_android version 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## 4.4.0
+
+* Bump braintree_android version to 3.6.0
+
 ## 4.3.1
 
 * Deprecate `amount` property on `DropInRequest`

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,7 +58,7 @@ android.buildTypes.debug { type ->
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.4.1'
+    api 'com.braintreepayments.api:braintree:3.6.0'
     api 'com.braintreepayments:card-form:4.2.0'
     api 'com.braintreepayments.api:three-d-secure:3.4.1'
     implementation 'androidx.cardview:cardview:1.0.0'


### PR DESCRIPTION
### Summary of changes

 - Bump core SDK `braintree_android` version 3.6.0

 ### Checklist

 - [X] Added a changelog entry
