### PR TITLE
Ignore 3DSecure 2.0 tests

### DIFF
--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -121,6 +121,9 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
+    @Ignore("Test fails due to Cardinal Activity changes that resulted in the authorization code " +
+            "input being untargetable with this current test.  Need to find the input element to " +
+            "target to continue with the authorization.")
     @Test(timeout = 60000)
     public void performsThreeDSecure2ChallengeVerification() {
         enableThreeDSecure();
@@ -141,6 +144,9 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
+    @Ignore("Test fails due to Cardinal Activity changes that resulted in the cancel button being " +
+            "untargetable with this current test.  Need to find the correct button element to" +
+            "target to cancel the authorization.")
     @Test(timeout = 60000)
     public void cancelsThreeDSecure2ChallengeVerification() {
         enableThreeDSecure();


### PR DESCRIPTION
These tests do pass manually.  The issue here is that due to upstream
changes to the native view activity in the Cardinal SDK, we've had some
trouble targeting the right elements with the `DeviceAutomator` test
framework we use.

We are just going to temporarily ignore them until we can allot time to
properly rewrite them as needed.

