### PR TITLE
Fix a Translation Error for French Locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+* Update `bt_add_card` string resource for french locales.
+
 ## 4.5.0
 * Bump braintree_android version to 3.7.2
 

--- a/Drop-In/src/main/res/values-fr-rCA/strings.xml
+++ b/Drop-In/src/main/res/values-fr-rCA/strings.xml
@@ -18,7 +18,7 @@
     <string name="bt_recent">Récent</string>
     <string name="bt_other">Autre</string>
     <string name="bt_select_payment_method">Sélectionner un mode de paiement</string>
-    <string name="bt_add_card">Enregistrer une carte</string>
+    <string name="bt_add_card">Ajouter la carte</string>
     <string name="bt_next">Suivant</string>
     <string name="bt_confirm">Confirmer</string>
     <string name="bt_scan_with_card_io">Lire avec card.io</string>

--- a/Drop-In/src/main/res/values-fr/strings.xml
+++ b/Drop-In/src/main/res/values-fr/strings.xml
@@ -18,7 +18,7 @@
     <string name="bt_recent">Récent</string>
     <string name="bt_other">Autre</string>
     <string name="bt_select_payment_method">Sélectionner un mode de paiement</string>
-    <string name="bt_add_card">Enregistrer une carte</string>
+    <string name="bt_add_card">Ajouter la carte</string>
     <string name="bt_next">Suivant</string>
     <string name="bt_confirm">Confirmer</string>
     <string name="bt_scan_with_card_io">Scanner avec card.io</string>


### PR DESCRIPTION
## Fix a Translation Error for French Locale

### Summary of changes

 - Update `bt_add_card` string resource for french locales.

 ### Checklist

 - [x] Added a changelog entry
