### PR TITLE
Add 3DS support for non-network tokenized Google Pay cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Bump card-form version to 4.3.0 (Updates Card icons)
 * Update payment method icons (fixes issue where Google Pay icon did not meet new [brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines))
 * Update `bt_add_card` string resource for french locales.
+* Bump braintree_android version to 3.10.0
+* Add 3DS support for non-network tokenized Google Pay cards
 
 ## 4.5.0
 * Bump braintree_android version to 3.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Bump card-form version to 4.3.0 (Updates Card icons)
 * Update payment method icons (fixes issue where Google Pay icon did not meet new [brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines))
 * Update `bt_add_card` string resource for french locales.
-* Bump braintree_android version to 3.10.0
 * Add 3DS support for non-network tokenized Google Pay cards
 
 ## 4.5.0

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/DropInActivity.java
@@ -41,6 +41,7 @@ import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.interfaces.PaymentMethodNoncesUpdatedListener;
 import com.braintreepayments.api.models.CardNonce;
 import com.braintreepayments.api.models.Configuration;
+import com.braintreepayments.api.models.GooglePaymentCardNonce;
 import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 import com.braintreepayments.api.models.ThreeDSecureRequest;
@@ -200,7 +201,8 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
 
     @Override
     public void onPaymentMethodNonceCreated(final PaymentMethodNonce paymentMethodNonce) {
-        if (!mPerformedThreeDSecureVerification && paymentMethodNonce instanceof CardNonce &&
+        if (!mPerformedThreeDSecureVerification &&
+                paymentMethodCanPerformThreeDSecureVerification(paymentMethodNonce) &&
                 shouldRequestThreeDSecureVerification()) {
             mPerformedThreeDSecureVerification = true;
             mLoadingViewSwitcher.setDisplayedChild(0);
@@ -229,6 +231,18 @@ public class DropInActivity extends BaseActivity implements ConfigurationListene
                 finish(paymentMethodNonce, mDeviceData);
             }
         });
+    }
+
+    private boolean paymentMethodCanPerformThreeDSecureVerification(final PaymentMethodNonce paymentMethodNonce) {
+        if (paymentMethodNonce instanceof CardNonce) {
+            return true;
+        }
+
+        if (paymentMethodNonce instanceof GooglePaymentCardNonce) {
+            return ((GooglePaymentCardNonce) paymentMethodNonce).isNetworkTokenized() == false;
+        }
+
+        return false;
     }
 
     @Override

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -432,7 +432,7 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    public void onPaymentMethodNonceCreated_requestsThreeDSecureVerificationForNonNetworkTokenizedGooglePay()
+    public void onPaymentMethodNonceCreated_requestsThreeDSecureVerificationForNonNetworkTokenizedGooglePayWhenEnabled()
             throws Exception {
         PackageManager packageManager = mockPackageManagerSupportsThreeDSecure();
         Context context = spy(RuntimeEnvironment.application);

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -24,6 +24,7 @@ import com.braintreepayments.api.interfaces.HttpResponseCallback;
 import com.braintreepayments.api.internal.BraintreeSharedPreferences;
 import com.braintreepayments.api.models.BraintreeRequestCodes;
 import com.braintreepayments.api.models.CardNonce;
+import com.braintreepayments.api.models.GooglePaymentCardNonce;
 import com.braintreepayments.api.models.PayPalAccountNonce;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 import com.braintreepayments.api.test.TestConfigurationBuilder;
@@ -63,7 +64,6 @@ import static junit.framework.Assert.assertTrue;
 import static org.assertj.android.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -407,7 +407,7 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    public void onPaymentMethodNonceCreated_requestsThreeDSecureVerificationWhenEnabled()
+    public void onPaymentMethodNonceCreated_requestsThreeDSecureVerificationForCardWhenEnabled()
             throws Exception {
         PackageManager packageManager = mockPackageManagerSupportsThreeDSecure();
         Context context = spy(RuntimeEnvironment.application);
@@ -429,6 +429,57 @@ public class DropInActivityUnitTest {
 
         verify(mActivity.httpClient).post(matches(BraintreeUnitTestHttpClient.THREE_D_SECURE_LOOKUP),
                 anyString(), any(HttpResponseCallback.class));
+    }
+
+    @Test
+    public void onPaymentMethodNonceCreated_requestsThreeDSecureVerificationForNonNetworkTokenizedGooglePay()
+            throws Exception {
+        PackageManager packageManager = mockPackageManagerSupportsThreeDSecure();
+        Context context = spy(RuntimeEnvironment.application);
+        when(context.getPackageManager()).thenReturn(packageManager);
+        mActivity.context = context;
+        mActivity.setDropInRequest(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .amount("1.00")
+                .requestThreeDSecureVerification(true));
+        mActivity.httpClient = spy(new BraintreeUnitTestHttpClient()
+                .configuration(new TestConfigurationBuilder()
+                        .threeDSecureEnabled(true)
+                        .build()));
+        mActivityController.setup();
+
+        GooglePaymentCardNonce googlePaymentCardNonce = GooglePaymentCardNonce.fromJson(
+                stringFromFixture("responses/google_pay_non_network_tokenized_response.json"));
+
+        mActivity.onPaymentMethodNonceCreated(googlePaymentCardNonce);
+
+        verify(mActivity.httpClient).post(matches(BraintreeUnitTestHttpClient.THREE_D_SECURE_LOOKUP),
+                anyString(), any(HttpResponseCallback.class));
+    }
+
+    @Test
+    public void onPaymentMethodNonceCreated_skipsThreeDSecureVerificationForNetworkTokenizedGooglePay()
+            throws Exception {
+        PackageManager packageManager = mockPackageManagerSupportsThreeDSecure();
+        Context context = spy(RuntimeEnvironment.application);
+        when(context.getPackageManager()).thenReturn(packageManager);
+        mActivity.context = context;
+        mActivity.setDropInRequest(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .amount("1.00")
+                .requestThreeDSecureVerification(true));
+        mActivity.httpClient = spy(new BraintreeUnitTestHttpClient()
+                .configuration(new TestConfigurationBuilder()
+                        .threeDSecureEnabled(true)
+                        .build()));
+        mActivityController.setup();
+
+        GooglePaymentCardNonce googlePaymentCardNonce = GooglePaymentCardNonce.fromJson(
+                stringFromFixture("responses/google_pay_network_tokenized_response.json"));
+
+        mActivity.onPaymentMethodNonceCreated(googlePaymentCardNonce);
+
+        verify(mActivity.httpClient, never()).post(matches(BraintreeUnitTestHttpClient.THREE_D_SECURE_LOOKUP), anyString(), any(HttpResponseCallback.class));
     }
 
     @Test

--- a/Drop-In/src/test/resources/fixtures/responses/google_pay_network_tokenized_response.json
+++ b/Drop-In/src/test/resources/fixtures/responses/google_pay_network_tokenized_response.json
@@ -1,0 +1,16 @@
+{
+  "apiVersionMinor": 0,
+  "apiVersion": 2,
+  "paymentMethodData": {
+    "description": "Visa •••• 1234",
+    "tokenizationData": {
+      "type": "PAYMENT_GATEWAY",
+      "token": "{\"androidPayCards\":[{\"type\":\"AndroidPayCard\",\"nonce\":\"d887f42c-bda5-091a-0798-af42d3ed173e\",\"description\":\"Android Pay\",\"consumed\":false,\"details\":{\"cardType\":\"Visa\",\"lastTwo\":\"34\",\"lastFour\":\"1234\",\"isNetworkTokenized\":true},\"binData\":{\"prepaid\":\"No\",\"healthcare\":\"No\",\"debit\":\"No\",\"durbinRegulated\":\"No\",\"commercial\":\"No\",\"payroll\":\"No\",\"issuingBank\":\"Issuing Bank USA\",\"countryOfIssuance\":\"USA\",\"productId\":\"A\"}}]}"
+    },
+    "type": "CARD",
+    "info": {
+      "cardNetwork": "VISA",
+      "cardDetails": "1234"
+    }
+  }
+}

--- a/Drop-In/src/test/resources/fixtures/responses/google_pay_non_network_tokenized_response.json
+++ b/Drop-In/src/test/resources/fixtures/responses/google_pay_non_network_tokenized_response.json
@@ -1,0 +1,16 @@
+{
+  "apiVersionMinor": 0,
+  "apiVersion": 2,
+  "paymentMethodData": {
+    "description": "Visa •••• 1234",
+    "tokenizationData": {
+      "type": "PAYMENT_GATEWAY",
+      "token": "{\"androidPayCards\":[{\"type\":\"AndroidPayCard\",\"nonce\":\"d887f42c-bda5-091a-0798-af42d3ed173e\",\"description\":\"Android Pay\",\"consumed\":false,\"details\":{\"cardType\":\"Visa\",\"lastTwo\":\"34\",\"lastFour\":\"1234\",\"isNetworkTokenized\":false},\"binData\":{\"prepaid\":\"No\",\"healthcare\":\"No\",\"debit\":\"No\",\"durbinRegulated\":\"No\",\"commercial\":\"No\",\"payroll\":\"No\",\"issuingBank\":\"Issuing Bank USA\",\"countryOfIssuance\":\"USA\",\"productId\":\"A\"}}]}"
+    },
+    "type": "CARD",
+    "info": {
+      "cardNetwork": "VISA",
+      "cardDetails": "1234"
+    }
+  }
+}


### PR DESCRIPTION
### Summary of changes

 - Runs 3DS verification for non-network tokenized Google Pay cards if 3DS is enabled as well.

 ### Checklist

 - [X] Added a changelog entry

### Authors

- @billwerges 
- @demerino 
