### PR TITLE
Fix test expiry date and refactor test client token fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Ref: https://medium.com/@fawwazyusran/how-to-travis-ci-working-for-android-api-level-28-2fde7292813c
 language: android
 jdk: oraclejdk8
 notifications:
@@ -7,12 +8,13 @@ sudo: true
 android:
   components:
     - tools
-    - tools
     - platform-tools
-    - build-tools-28.0.3
-    - android-28
     - extra-google-m2repository
 before_install:
+  - rm -fr $HOME/.gradle/caches
+  - touch $HOME/.android/repositories.cfg
   - yes | sdkmanager "platforms;android-28"
-script: ./gradlew --stacktrace lint test :Demo:assembleDebug :Demo:assembleRelease
-after_success: ./script/deploy_snapshot.sh
+  - yes | sdkmanager "build-tools;28.0.3"
+script: ./gradlew --stacktrace test
+#after_success: ./script/deploy_snapshot.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-# Ref: https://medium.com/@fawwazyusran/how-to-travis-ci-working-for-android-api-level-28-2fde7292813c
 language: android
 jdk: oraclejdk8
 notifications:
@@ -8,13 +7,12 @@ sudo: true
 android:
   components:
     - tools
+    - tools
     - platform-tools
+    - build-tools-28.0.3
+    - android-28
     - extra-google-m2repository
 before_install:
-  - rm -fr $HOME/.gradle/caches
-  - touch $HOME/.android/repositories.cfg
   - yes | sdkmanager "platforms;android-28"
-  - yes | sdkmanager "build-tools;28.0.3"
-script: ./gradlew --stacktrace test
-#after_success: ./script/deploy_snapshot.sh
-
+script: ./gradlew --stacktrace lint test :Demo:assembleDebug :Demo:assembleRelease
+after_success: ./script/deploy_snapshot.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Braintree Android Drop-In Release Notes
 
 ## unreleased
+* Bump braintree_android version to 3.11.0
 * Bump card-form version to 4.3.0 (Updates Card icons)
 * Update payment method icons (fixes issue where Google Pay icon did not meet new [brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines))
 * Update `bt_add_card` string resource for french locales.

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,9 +58,9 @@ android.buildTypes.debug { type ->
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.7.2'
+    api 'com.braintreepayments.api:braintree:3.10.0'
     api 'com.braintreepayments:card-form:4.3.0'
-    api 'com.braintreepayments.api:three-d-secure:3.7.2'
+    api 'com.braintreepayments.api:three-d-secure:3.10.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,9 +58,9 @@ android.buildTypes.debug { type ->
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.10.0'
+    api 'com.braintreepayments.api:braintree:3.11.0'
     api 'com.braintreepayments:card-form:4.3.0'
-    api 'com.braintreepayments.api:three-d-secure:3.10.0'
+    api 'com.braintreepayments.api:three-d-secure:3.11.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'
 

--- a/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/ExpirationDate.java
+++ b/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/ExpirationDate.java
@@ -2,5 +2,5 @@ package com.braintreepayments.api.test;
 
 public class ExpirationDate {
 
-    public static final String VALID_EXPIRATION = "1219";
+    public static final String VALID_EXPIRATION = "1229";
 }

--- a/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/ExpirationDate.java
+++ b/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/ExpirationDate.java
@@ -1,6 +1,12 @@
 package com.braintreepayments.api.test;
 
+import java.util.Calendar;
+
 public class ExpirationDate {
 
-    public static final String VALID_EXPIRATION = "1229";
+    public static final String VALID_EXPIRATION = "12" + validExpirationYear();
+
+    public static String validExpirationYear() {
+        return String.valueOf(Calendar.getInstance().get(Calendar.YEAR) + 1).substring(2);
+    }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
@@ -53,6 +53,7 @@ import static com.braintreepayments.api.test.CardNumber.UNIONPAY_SMS_NOT_REQUIRE
 import static com.braintreepayments.api.test.CardNumber.VISA;
 import static com.braintreepayments.api.test.PackageManagerUtils.mockPackageManagerSupportsThreeDSecure;
 import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KEY;
+import static com.braintreepayments.api.test.UnitTestFixturesHelper.base64EncodedClientTokenFromFixture;
 import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -256,7 +257,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_CAPABILITIES_PATH,
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -329,7 +330,7 @@ public class AddCardActivityUnitTest {
 
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -358,7 +359,7 @@ public class AddCardActivityUnitTest {
 
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -388,7 +389,7 @@ public class AddCardActivityUnitTest {
 
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_REQUIRED)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -415,7 +416,7 @@ public class AddCardActivityUnitTest {
                 .errorResponse(BraintreeUnitTestHttpClient.TOKENIZE_CREDIT_CARD, 422,
                         stringFromFixture("responses/credit_card_error_response.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -451,7 +452,7 @@ public class AddCardActivityUnitTest {
                 .errorResponse(BraintreeUnitTestHttpClient.TOKENIZE_CREDIT_CARD, 422,
                         stringFromFixture("responses/credit_card_non_number_error_response.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, VISA);
@@ -489,7 +490,7 @@ public class AddCardActivityUnitTest {
                 .errorResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH, 422,
                         stringFromFixture("responses/unionpay_enrollment_error_response.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -632,7 +633,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -661,7 +662,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_CAPABILITIES_PATH,
                         stringFromFixture("responses/unionpay_capabilities_success_response.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -685,7 +686,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -716,7 +717,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.TOKENIZE_CREDIT_CARD,
                         stringFromFixture("payment_methods/unionpay_credit_card.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_SMS_NOT_REQUIRED);
@@ -753,7 +754,7 @@ public class AddCardActivityUnitTest {
                         "^(?!cardholderName).*$");
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_SMS_NOT_REQUIRED);
@@ -790,7 +791,7 @@ public class AddCardActivityUnitTest {
                         "cardholderName\":\"Brian Tree\"");
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_SMS_NOT_REQUIRED);
@@ -828,7 +829,7 @@ public class AddCardActivityUnitTest {
                         "cardholderName\":\"Brian Tree\"");
         mActivity.setDropInRequest(new DropInRequest()
                 .cardholderNameStatus(CardForm.FIELD_REQUIRED)
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_SMS_NOT_REQUIRED);
@@ -879,7 +880,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
@@ -912,7 +913,7 @@ public class AddCardActivityUnitTest {
                 .successResponse(BraintreeUnitTestHttpClient.UNIONPAY_ENROLLMENT_PATH,
                         stringFromFixture("responses/unionpay_enrollment_sms_required.json"));
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json")));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
@@ -22,6 +22,7 @@ import org.robolectric.shadows.ShadowActivity;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_FIRST_USER;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_OK;
 import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KEY;
+import static com.braintreepayments.api.test.UnitTestFixturesHelper.base64EncodedClientTokenFromFixture;
 import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -130,7 +131,7 @@ public class BaseActivityUnitTest {
     @Test
     public void getBraintreeFragment_setsClientTokenPresentWhenAClientTokenIsPresent() throws InvalidArgumentException {
         setup(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"))
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json"))
                 .getIntent(RuntimeEnvironment.application));
 
         mActivity.getBraintreeFragment();

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInActivityUnitTest.java
@@ -54,6 +54,7 @@ import static com.braintreepayments.api.test.PackageManagerUtils.mockPackageMana
 import static com.braintreepayments.api.test.ReflectionHelper.getField;
 import static com.braintreepayments.api.test.ReflectionHelper.setField;
 import static com.braintreepayments.api.test.TestTokenizationKey.TOKENIZATION_KEY;
+import static com.braintreepayments.api.test.UnitTestFixturesHelper.base64EncodedClientTokenFromFixture;
 import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -206,7 +207,7 @@ public class DropInActivityUnitTest {
         when(context.getPackageManager()).thenReturn(packageManager);
         mActivity.context = context;
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"))
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json"))
                 .amount("1.00")
                 .requestThreeDSecureVerification(true));
         mActivity.httpClient = spy(new BraintreeUnitTestHttpClient()
@@ -234,7 +235,7 @@ public class DropInActivityUnitTest {
         when(context.getPackageManager()).thenReturn(packageManager);
         mActivity.context = context;
         mActivity.setDropInRequest(new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"))
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json"))
                 .amount("1.00")
                 .requestThreeDSecureVerification(true));
         mActivity.httpClient = spy(new BraintreeUnitTestHttpClient()
@@ -294,11 +295,12 @@ public class DropInActivityUnitTest {
                 .paypalEnabled(true)
                 .build();
         DropInRequest dropInRequest = new DropInRequest()
-                .clientToken(stringFromFixture("client_token.json"));
+                .clientToken(base64EncodedClientTokenFromFixture("client_token.json"));
         mActivity.setDropInRequest(dropInRequest);
         BraintreeUnitTestHttpClient httpClient = new BraintreeUnitTestHttpClient()
                 .configuration(configuration)
-                .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS, stringFromFixture("responses/get_payment_methods_two_cards_response.json"));
+                .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
+                        stringFromFixture("responses/get_payment_methods_two_cards_response.json"));
         setup(httpClient);
         assertEquals(2, ((ListView) mActivity.findViewById(R.id.bt_supported_payment_methods)).getAdapter().getCount());
         assertEquals(2, ((RecyclerView) mActivity.findViewById(R.id.bt_vaulted_payment_methods)).getAdapter().getItemCount());
@@ -479,7 +481,8 @@ public class DropInActivityUnitTest {
                 .configuration(new TestConfigurationBuilder().build())
                 .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
                         stringFromFixture("responses/get_payment_methods_response.json"));
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(
+                base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         RecyclerView recyclerView = mActivity.findViewById(R.id.bt_vaulted_payment_methods);
@@ -542,7 +545,8 @@ public class DropInActivityUnitTest {
                 .configuration(new TestConfigurationBuilder().build())
                 .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
                        stringFromFixture("responses/get_payment_methods_response.json"));
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(
+                base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         assertThat(mActivity.findViewById(R.id.bt_vaulted_payment_methods)).isShown();
@@ -556,7 +560,7 @@ public class DropInActivityUnitTest {
                 .configuration(new TestConfigurationBuilder().build())
                 .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
                         stringFromFixture("responses/get_payment_methods_google_pay_response.json"));
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(base64EncodedClientTokenFromFixture("client_token.json")));
         setup(httpClient);
 
         assertThat(mActivity.findViewById(R.id.bt_vaulted_payment_methods)).isShown();
@@ -648,7 +652,8 @@ public class DropInActivityUnitTest {
 
     @Test
     public void onActivityResult_addCardCancelRefreshesVaultedPaymentMethods() {
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(
+                base64EncodedClientTokenFromFixture("client_token.json")));
         BraintreeUnitTestHttpClient httpClient = spy(new BraintreeUnitTestHttpClient()
                 .configuration(new TestConfigurationBuilder().build()))
                 .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
@@ -665,7 +670,8 @@ public class DropInActivityUnitTest {
 
     @Test
     public void onActivityResult_nonCardCancelDoesNotRefreshVaultedPaymentMethods() {
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(
+                base64EncodedClientTokenFromFixture("client_token.json")));
         BraintreeUnitTestHttpClient httpClient = spy(new BraintreeUnitTestHttpClient()
                 .configuration(new TestConfigurationBuilder().build()))
                 .successResponse(BraintreeUnitTestHttpClient.GET_PAYMENT_METHODS,
@@ -786,7 +792,8 @@ public class DropInActivityUnitTest {
 
     @Test
     public void onActivityResult_whenVaultManagerResultOk_refreshesVaultedPaymentMethods() {
-        mActivity.setDropInRequest(new DropInRequest().clientToken(stringFromFixture("client_token.json")));
+        mActivity.setDropInRequest(new DropInRequest().clientToken(
+                base64EncodedClientTokenFromFixture("client_token.json")));
 
         BraintreeUnitTestHttpClient httpClient = spy(new BraintreeUnitTestHttpClient()
                 .configuration(new TestConfigurationBuilder().build()))

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInResultUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/DropInResultUnitTest.java
@@ -38,6 +38,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 
 import static com.braintreepayments.api.BraintreeFragmentTestUtils.setHttpClient;
+import static com.braintreepayments.api.test.UnitTestFixturesHelper.base64EncodedClientTokenFromFixture;
 import static com.braintreepayments.api.test.UnitTestFixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -128,7 +129,7 @@ public class DropInResultUnitTest {
         DropInResult.DropInResultListener listener = new DropInResult.DropInResultListener() {
             @Override
             public void onError(Exception exception) {
-                assertEquals("Client token was invalid", exception.getMessage());
+                assertEquals("Authorization provided is invalid: not a client token", exception.getMessage());
                 mCountDownLatch.countDown();
             }
 
@@ -166,7 +167,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
     }
@@ -236,7 +237,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         List<BraintreeListener> listeners = fragment.getListeners();
@@ -269,7 +270,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         List<BraintreeListener> listeners = fragment.getListeners();
@@ -296,7 +297,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
     }
@@ -321,7 +322,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
     }
@@ -356,7 +357,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         List<BraintreeListener> listeners = fragment.getListeners();
@@ -385,7 +386,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         assertEquals(0, fragment.getListeners().size());
@@ -412,7 +413,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
     }
@@ -438,7 +439,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
     }
@@ -473,7 +474,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         List<BraintreeListener> listeners = fragment.getListeners();
@@ -502,7 +503,7 @@ public class DropInResultUnitTest {
             }
         };
 
-        DropInResult.fetchDropInResult(mActivity, stringFromFixture("client_token.json"), listener);
+        DropInResult.fetchDropInResult(mActivity, base64EncodedClientTokenFromFixture("client_token.json"), listener);
 
         mCountDownLatch.await();
         List<BraintreeListener> listeners = fragment.getListeners();
@@ -511,7 +512,7 @@ public class DropInResultUnitTest {
 
     private BraintreeFragment setupFragment(BraintreeHttpClient httpClient) throws InvalidArgumentException {
         BraintreeFragment fragment = BraintreeFragment.newInstance(mActivity,
-                stringFromFixture("client_token.json"));
+                base64EncodedClientTokenFromFixture("client_token.json"));
         setHttpClient(fragment, httpClient);
         ConfigurationManagerTestUtils.setFetchingConfiguration(false);
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/VaultManagerActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/VaultManagerActivityUnitTest.java
@@ -78,7 +78,7 @@ public class VaultManagerActivityUnitTest {
         mPaymentMethodNonces.add(payPalNonce);
 
         DropInRequest dropInRequest = new DropInRequest()
-                .clientToken(UnitTestFixturesHelper.stringFromFixture("client_token.json"));
+                .clientToken(UnitTestFixturesHelper.base64EncodedClientTokenFromFixture("client_token.json"));
 
         Bundle in = new Bundle();
         in.putParcelableArrayList(EXTRA_PAYMENT_METHOD_NONCES, (ArrayList<? extends Parcelable>) mPaymentMethodNonces);

--- a/Drop-In/src/test/java/com/braintreepayments/api/test/UnitTestFixturesHelper.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/test/UnitTestFixturesHelper.java
@@ -30,6 +30,6 @@ public class UnitTestFixturesHelper {
     }
 
     public static String base64EncodedClientTokenFromFixture(String filename) {
-                return Base64.getEncoder().encodeToString(stringFromFixture(filename).getBytes());
+        return Base64.getEncoder().encodeToString(stringFromFixture(filename).getBytes());
     }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/test/UnitTestFixturesHelper.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/test/UnitTestFixturesHelper.java
@@ -1,7 +1,9 @@
 package com.braintreepayments.api.test;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 
 import static com.braintreepayments.api.test.StringUtils.getStringFromStream;
 
@@ -25,5 +27,9 @@ public class UnitTestFixturesHelper {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static String base64EncodedClientTokenFromFixture(String filename) {
+                return Base64.getEncoder().encodeToString(stringFromFixture(filename).getBytes());
     }
 }


### PR DESCRIPTION
### Summary of changes

 The expiry date helper const is no longer valid, and was preventing
tests from correctly running or testing the appropriate failures via
Robolectric.  Bumping this to a considerable date in the future should
be sufficient.

The refactor for the client token fixtures is due to a bugfix we
deployed [here](https://github.braintreeps.com/team-sdk/braintree-android/pull/446/files) that corrects an unintended behavior
where a merchant could pass a regular string as an auth.  This
reinforces the need to only pass encoded client token or UATs, or
tokenization keys, and rejects random strings as incorrectly formatted.

Since this branch is required to get https://github.com/braintree/braintree-android-drop-in/pull/182 passing, but wasn't specific to the work in that PR, it was moved to it's own branch and PR.  Ideally the two would be merged, but as both are fairly sizable, this makes them more easily reviewable.  Whether this PR is closed and the work merged into 182, or, this is merged directly into master first (though it relies on the braintree_android bump in 182 to pass tests) is up for consideration, either would technically work.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @Epreuve 
- @sshropshire 
