### PR TITLE
Add Dynamic Date to Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree Android Drop-In Release Notes
 
 ## unreleased
-* Bump braintree_android version to 3.11.0
+* Bump braintree_android version to 3.11.1
 * Bump card-form version to 4.3.0 (Updates Card icons)
 * Update payment method icons (fixes issue where Google Pay icon did not meet new [brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines))
 * Update `bt_add_card` string resource for french locales.

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -2,6 +2,9 @@ package com.braintreepayments.demo.test;
 
 import android.widget.Button;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.RequiresDevice;
+
 import com.braintreepayments.demo.Settings;
 import com.braintreepayments.demo.test.utilities.ExpirationDate;
 import com.braintreepayments.demo.test.utilities.TestHelper;
@@ -11,13 +14,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.RequiresDevice;
+import java.io.IOException;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
-import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECURE_VERIFICATON;
 import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECURE_2_CHALLENGE_VERIFICATON;
 import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECURE_2_FRICTIONLESS_VERIFICATON;
+import static com.braintreepayments.demo.test.utilities.CardNumber.THREE_D_SECURE_VERIFICATON;
 import static com.braintreepayments.demo.test.utilities.CardNumber.UNIONPAY_CREDIT;
 import static com.braintreepayments.demo.test.utilities.CardNumber.UNIONPAY_SMS_NOT_REQUIRED;
 import static com.braintreepayments.demo.test.utilities.CardNumber.VISA;
@@ -122,19 +124,18 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
-    @Ignore("Test fails due to Cardinal Activity changes that resulted in the authorization code " +
-            "input being untargetable with this current test.  Need to find the input element to " +
-            "target to continue with the authorization.")
     @Test(timeout = 60000)
-    public void performsThreeDSecure2ChallengeVerification() {
+    public void performsThreeDSecure2ChallengeVerification() throws IOException {
         enableThreeDSecure();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(THREE_D_SECURE_2_CHALLENGE_VERIFICATON);
 
         onDevice(withText("Purchase Authentication")).waitForExists();
-        onDevice(withText("Code")).perform(setText("1234"));
+        onDevice(withResourceId("com.braintreepayments.demo:id/codeEditTextField")).perform(click());
 
+        onDevice().typeText("1234");
+        onDevice().pressEnter();
         onDevice(withText("Submit")).waitForExists().waitForEnabled().perform(click());
 
         getNonceDetails().check(text(containsString("Card Last Two: 91")));
@@ -145,9 +146,6 @@ public class DropInTest extends TestHelper {
         onDevice(withTextStartingWith("created")).check(text(endsWith("authorized")));
     }
 
-    @Ignore("Test fails due to Cardinal Activity changes that resulted in the cancel button being " +
-            "untargetable with this current test.  Need to find the correct button element to" +
-            "target to cancel the authorization.")
     @Test(timeout = 60000)
     public void cancelsThreeDSecure2ChallengeVerification() {
         enableThreeDSecure();

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -3,6 +3,7 @@ package com.braintreepayments.demo.test;
 import android.widget.Button;
 
 import com.braintreepayments.demo.Settings;
+import com.braintreepayments.demo.test.utilities.ExpirationDate;
 import com.braintreepayments.demo.test.utilities.TestHelper;
 
 import org.junit.Before;
@@ -172,7 +173,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(UNIONPAY_CREDIT));
         onDevice(withText("12")).perform(click());
-        onDevice(withText("2019")).perform(click());
+        onDevice(withText(ExpirationDate.VALID_EXPIRATION_YEAR)).perform(click());
         onDevice().pressBack();
         onDevice(withText("CVN")).perform(setText("123"));
         onDevice(withText("Postal Code")).perform(setText("12345"));
@@ -201,7 +202,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(UNIONPAY_SMS_NOT_REQUIRED));
         onDevice(withText("12")).perform(click());
-        onDevice(withText("2019")).perform(click());
+        onDevice(withText(ExpirationDate.VALID_EXPIRATION_YEAR)).perform(click());
         onDevice().pressBack();
         onDevice(withText("CVN")).perform(setText("123"));
         onDevice(withText("Postal Code")).perform(setText("12345"));
@@ -228,7 +229,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(UNIONPAY_CREDIT));
         onDevice(withText("12")).perform(click());
-        onDevice(withText("2019")).perform(click());
+        onDevice(withText(ExpirationDate.VALID_EXPIRATION_YEAR)).perform(click());
         onDevice().pressBack();
         onDevice(withText("CVN")).perform(setText("123"));
         onDevice(withText("Postal Code")).perform(setText("12345"));

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/ExpirationDate.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/ExpirationDate.java
@@ -1,0 +1,9 @@
+package com.braintreepayments.demo.test.utilities;
+
+import java.util.Calendar;
+
+public class ExpirationDate {
+
+    public static final String VALID_EXPIRATION_YEAR =
+        String.valueOf(Calendar.getInstance().get(Calendar.YEAR) + 1);
+}

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
@@ -222,7 +222,7 @@ public class TestHelper {
 
     protected void performCardDetailsEntry() {
         onDevice(withText("12")).perform(click());
-        onDevice(withText("2019")).perform(click());
+        onDevice(withText(ExpirationDate.VALID_EXPIRATION_YEAR)).perform(click());
         onDevice().pressBack();
         onDevice(withText("CVV")).perform(setText("123"));
         onDevice(withText("Postal Code")).perform(setText("12345"));

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,9 +58,9 @@ android.buildTypes.debug { type ->
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.11.0'
+    api 'com.braintreepayments.api:braintree:3.11.1'
     api 'com.braintreepayments:card-form:4.3.0'
-    api 'com.braintreepayments.api:three-d-secure:3.11.0'
+    api 'com.braintreepayments.api:three-d-secure:3.11.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'
 


### PR DESCRIPTION
## Add Dynamic Date to Integration Tests

### Summary of changes

 - Add a dynamic expiration date to drop in integration tests
 - Bump core SDK version to 3.11.1
 - Re-enable 3DSv2 challenge verification integration test

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo @sshropshire
