### PR TITLE
Upgrade Braintree Android to 3.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Bump braintree_android version to 3.14.2
+* Bump braintree_android version to 3.14.2 (fixes [#305](https://github.com/braintree/braintree_android/issues/305))
+* Upgrade gradle build tools to 4.1.0
 
 ## 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Bump braintree_android version to 3.14.2 (fixes [#305](https://github.com/braintree/braintree_android/issues/305))
+* Bump braintree_android version to 3.14.2 (fixes [#197](https://github.com/braintree/braintree-android-drop-in/issues/197))
 * Upgrade gradle build tools to 4.1.0
 
 ## 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android version to 3.14.2
+
 ## 5.0.0
 
 * Add `vaultVenmo` option to `DropInRequest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Bump braintree_android version to 3.14.2 (fixes [#197](https://github.com/braintree/braintree-android-drop-in/issues/197))
-* Upgrade gradle build tools to 4.1.0
+* Upgrade Android Gradle Plugin to version 4.1.0
 
 ## 5.0.0
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -57,9 +57,9 @@ android {
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.14.1'
+    api 'com.braintreepayments.api:braintree:3.14.2'
     api 'com.braintreepayments:card-form:5.0.0'
-    api 'com.braintreepayments.api:three-d-secure:3.14.1'
+    api 'com.braintreepayments.api:three-d-secure:3.14.2'
 
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 29 11:39:56 PST 2019
+#Tue Oct 20 09:24:56 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
### Summary of changes

 - Bump braintree_android version to 3.14.2

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire 
- @sarahkoop 
