### PR TITLE
Update Braintree Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## unreleased
 
 * Fix issue where payment methods disabled on `DropInRequest` were displayed if previously vaulted (fixes #205)
+* Bump braintree_android version to 3.15.0 (fixes #208)
 
 ## 5.0.1
 
-* Bump braintree_android version to 3.14.2 (fixes [#197](https://github.com/braintree/braintree-android-drop-in/issues/197))
+* Bump braintree_android version to 3.14.2 (fixes #197)
 * Upgrade Android Gradle Plugin to version 4.1.0
 
 ## 5.0.0

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.14.2'
+    api 'com.braintreepayments.api:braintree:3.15.0'
     api 'com.braintreepayments:card-form:5.0.0'
     api 'com.braintreepayments.api:three-d-secure:3.14.2'
 


### PR DESCRIPTION
### Summary of changes

 - Bump `braintree-android` version to `3.15.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop
- @sshropshire
