### PR TITLE
Update 3DS Version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Update Google Pay icon to meet updated [brand guidelines](https://developers.google.com/pay/api/android/guides/brand-guidelines#google-pay-logo-mark)
+* Bump three-d-secure version to 3.15.0
 
 ## 5.0.2
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     api 'com.braintreepayments.api:braintree:3.15.0'
     api 'com.braintreepayments:card-form:5.0.0'
-    api 'com.braintreepayments.api:three-d-secure:3.14.2'
+    api 'com.braintreepayments.api:three-d-secure:3.15.0'
 
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :tests => [:unit_tests, :integration_tests]
 
 desc "Run Android unit tests"
 task :unit_tests => :lint do
-  sh "./gradlew --continue test"
+  sh "./gradlew --continue testRelease"
 end
 
 desc "Run Android tests on a device or emulator"


### PR DESCRIPTION
### Summary of changes

 - Update `three-d-secure` to `3.15.0` to align with core dependency
 - Fix rake task that was running all unit tests twice

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
- @sshropshire 
