### PR TITLE
Fix null pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Update android-card-form version to 5.1.0 (fixes #212)
+* Fix null pointer crash in `BaseActivity#shouldRequestThreeDSecureVerification` (fixes #207)
 
 ## 5.1.0
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/BaseActivity.java
@@ -66,6 +66,11 @@ public class BaseActivity extends AppCompatActivity {
         boolean hasAmount = !TextUtils.isEmpty(mDropInRequest.getAmount()) ||
                 (mDropInRequest.getThreeDSecureRequest() != null && !TextUtils.isEmpty(mDropInRequest.getThreeDSecureRequest().getAmount()));
 
+        // TODO: NEXT_MAJOR_VERSION use BraintreeClient#getConfiguration and don't cache configuration in memory
+        if (mConfiguration == null) {
+            return false;
+        }
+
         return mDropInRequest.shouldRequestThreeDSecureVerification() &&
                 mConfiguration.isThreeDSecureEnabled() &&
                 hasAmount;

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/BaseActivityUnitTest.java
@@ -234,6 +234,18 @@ public class BaseActivityUnitTest {
     }
 
     @Test
+    public void shouldRequestThreeDSecureVerification_returnsFalseWhenConfigurationIsNull() {
+        setup(new DropInRequest()
+                .tokenizationKey(TOKENIZATION_KEY)
+                .requestThreeDSecureVerification(true)
+                .threeDSecureRequest(new ThreeDSecureRequest().amount("2.00"))
+                .getIntent(RuntimeEnvironment.application));
+        mActivity.mConfiguration = null;
+
+        assertFalse(mActivity.shouldRequestThreeDSecureVerification());
+    }
+
+    @Test
     public void finish_finishesWithPaymentMethodNonceAndDeviceDataInDropInResult()
             throws JSONException {
         CardNonce cardNonce = CardNonce.fromJson(Fixtures.VISA_CREDIT_CARD_RESPONSE);


### PR DESCRIPTION
### Summary of changes

 - Add null check for configuration in `BaseActivity#shouldRequestThreeDSecureVerification` (fixes #207)
 
Note: this patch is to temporarily resolve the null pointer error application crashes, but the long term fix will require a major version update.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 
