### PR TITLE
Add SourcesJar and JavadocsJar to Maven Publish

### DIFF
--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -98,11 +98,6 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-artifacts {
-    archives javadocsJar
-    archives sourcesJar
-}
-
 signing {
     required {
         !version.endsWith("SNAPSHOT") && !version.endsWith("DEVELOPMENT")
@@ -123,6 +118,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
+
+                artifact sourcesJar
+                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'drop-in'


### PR DESCRIPTION
### Summary of changes

 - Fix an issue that caused javadocs and source jars to be omitted from `maven-publish` artifacts

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop  
- @sshropshire