### PR TITLE
Bump card-form to 5.X.X (Support Discover 19 Digits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump card-form version to 5.X.X
+
 ## 5.2.1
 
 * Bump card-form version to 5.1.1

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -59,7 +59,7 @@ android {
 
 dependencies {
     api 'com.braintreepayments.api:braintree:3.15.0'
-    api 'com.braintreepayments:card-form:5.1.1'
+    api 'com.braintreepayments:card-form:5.1.2-SNAPSHOT'
     api 'com.braintreepayments.api:three-d-secure:3.15.0'
 
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/AddCardView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/AddCardView.java
@@ -182,10 +182,14 @@ public class AddCardView extends LinearLayout implements OnCardFormSubmitListene
 
     @Override
     public void onCardFormValid(boolean valid) {
-        if (isValid()) {
+        if (isMaxCardLength() && isValid()) {
             mAnimatedButtonView.showLoading();
             callAddPaymentUpdateListener();
         }
+    }
+
+    private boolean isMaxCardLength() {
+       return mCardForm.getCardEditText().length() == mCardForm.getCardEditText().getCardType().getMaxCardLength();
     }
 
     private boolean isValid() {

--- a/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/AddCardView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/dropin/view/AddCardView.java
@@ -189,7 +189,7 @@ public class AddCardView extends LinearLayout implements OnCardFormSubmitListene
     }
 
     private boolean isMaxCardLength() {
-       return mCardForm.getCardEditText().length() == mCardForm.getCardEditText().getCardType().getMaxCardLength();
+        return mCardForm.getCardEditText().length() == mCardForm.getCardEditText().getCardType().getMaxCardLength();
     }
 
     private boolean isValid() {

--- a/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
+++ b/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
@@ -7,6 +7,7 @@ public class CardNumber {
     public static final String INVALID_VISA = "4111111111111112";
     public static final String AMEX = "378282246310005";
     public static final String INVALID_AMEX = "371111111111111";
+    public static final String DISCOVER_16 = "6011000991300009";
     public static final String DISCOVER_19 = "6510000000000000069";
 
     public static final String THREE_D_SECURE_VERIFICATON = "4000000000000002";

--- a/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
+++ b/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
@@ -7,6 +7,7 @@ public class CardNumber {
     public static final String INVALID_VISA = "4111111111111112";
     public static final String AMEX = "378282246310005";
     public static final String INVALID_AMEX = "371111111111111";
+    public static final String DISCOVER_19 = "6510000000000000069";
 
     public static final String THREE_D_SECURE_VERIFICATON = "4000000000000002";
     public static final String THREE_D_SECURE_VERIFICATON_NOT_REQUIRED = "4000000000000051";

--- a/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
+++ b/Drop-In/src/sharedTest/java/com.braintreepayments.api.test/CardNumber.java
@@ -24,6 +24,7 @@ public class CardNumber {
 
     public static final String UNIONPAY_INTEGRATION_CREDIT = "6222821234560017";
     public static final String UNIONPAY_INTEGRATION_DEBIT = "6223164991230014";
+    public static final String UNIONPAY_19 = "6212345678900000003";
     public static final String UNIONPAY_CREDIT = "6212345678901232";
     public static final String UNIONPAY_DEBIT = "6212345678901265";
     public static final String UNIONPAY_SINGLE_STEP_SALE = "6212345678900093";

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/AddCardActivityUnitTest.java
@@ -47,6 +47,7 @@ import static androidx.appcompat.app.AppCompatActivity.RESULT_FIRST_USER;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_OK;
 import static com.braintreepayments.api.test.Assertions.assertIsANonce;
 import static com.braintreepayments.api.test.CardNumber.AMEX;
+import static com.braintreepayments.api.test.CardNumber.UNIONPAY_19;
 import static com.braintreepayments.api.test.CardNumber.UNIONPAY_CREDIT;
 import static com.braintreepayments.api.test.CardNumber.UNIONPAY_DEBIT;
 import static com.braintreepayments.api.test.CardNumber.UNIONPAY_SMS_NOT_REQUIRED;
@@ -258,7 +259,7 @@ public class AddCardActivityUnitTest {
                 .clientToken(base64EncodedClientTokenFromFixture(Fixtures.CLIENT_TOKEN)));
         setup(httpClient);
 
-        setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
+        setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_19);
         assertThat(mEditCardView).isVisible();
         assertThat(mAddCardView).isGone();
 
@@ -266,7 +267,7 @@ public class AddCardActivityUnitTest {
         assertThat(mAddCardView).isVisible();
         assertThat(mEditCardView).isGone();
 
-        setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_CREDIT);
+        setText(mAddCardView, R.id.bt_card_form_card_number, UNIONPAY_19);
         mAddCardView.findViewById(R.id.bt_button).performClick();
         assertThat(mEditCardView).isVisible();
         assertThat(mAddCardView).isGone();

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import androidx.appcompat.app.AppCompatActivity;
 
 import static com.braintreepayments.api.test.CardNumber.AMEX;
+import static com.braintreepayments.api.test.CardNumber.DISCOVER_16;
 import static com.braintreepayments.api.test.CardNumber.DISCOVER_19;
 import static com.braintreepayments.api.test.CardNumber.VISA;
 import static com.braintreepayments.api.test.ReflectionHelper.getField;
@@ -63,7 +64,7 @@ public class AddCardViewUnitTest {
         mView = mActivity.findViewById(R.id.bt_add_card_view);
         mView.setup(mActivity, (Configuration) new TestConfigurationBuilder()
                 .creditCards(new TestConfigurationBuilder.TestCardConfigurationBuilder()
-                        .supportedCardTypes(PaymentMethodType.VISA.getCanonicalName()))
+                        .supportedCardTypes(PaymentMethodType.VISA.getCanonicalName(), PaymentMethodType.DISCOVER.getCanonicalName()))
                 .buildConfiguration(), false);
     }
 
@@ -375,8 +376,9 @@ public class AddCardViewUnitTest {
         AddPaymentUpdateListener listener = mock(AddPaymentUpdateListener.class);
         mView.setAddPaymentUpdatedListener(listener);
 
-        mView.getCardForm().getCardEditText().setText(VISA);
+        mView.getCardForm().getCardEditText().setText(DISCOVER_19);
 
+        assertTrue(mView.getCardForm().isValid());
         assertThat(mView.findViewById(R.id.bt_animated_button_loading_indicator)).isVisible();
         verify(listener).onPaymentUpdated(mView);
     }
@@ -386,8 +388,9 @@ public class AddCardViewUnitTest {
         AddPaymentUpdateListener listener = mock(AddPaymentUpdateListener.class);
         mView.setAddPaymentUpdatedListener(listener);
 
-        mView.getCardForm().getCardEditText().setText(DISCOVER_19);
+        mView.getCardForm().getCardEditText().setText(DISCOVER_16);
 
+        assertTrue(mView.getCardForm().isValid());
         assertThat(mView.findViewById(R.id.bt_animated_button_loading_indicator)).isGone();
         verifyZeroInteractions(listener);
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
@@ -265,7 +265,7 @@ public class AddCardViewUnitTest {
                 R.id.bt_supported_card_types);
         List<PaddedImageSpan> allSpans = Arrays.asList(new SpannableString(supportedCardTypesView.getText())
                 .getSpans(0, supportedCardTypesView.length(), PaddedImageSpan.class));
-        assertEquals(1, allSpans.size());
+        assertEquals(2, allSpans.size());
         assertFalse((Boolean) getField(allSpans.get(0), "mDisabled"));
     }
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/dropin/view/AddCardViewUnitTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import androidx.appcompat.app.AppCompatActivity;
 
 import static com.braintreepayments.api.test.CardNumber.AMEX;
+import static com.braintreepayments.api.test.CardNumber.DISCOVER_19;
 import static com.braintreepayments.api.test.CardNumber.VISA;
 import static com.braintreepayments.api.test.ReflectionHelper.getField;
 import static com.braintreepayments.api.test.TestConfigurationBuilder.basicConfig;
@@ -370,7 +371,7 @@ public class AddCardViewUnitTest {
     }
 
     @Test
-    public void onCardFormValid_showLoadingIndicatorAndCallsListenerWhenCardFormIsValid() {
+    public void onCardFormValid_showLoadingIndicatorAndCallsListenerWhenCardFormIsValidAndCardIsMaxLength() {
         AddPaymentUpdateListener listener = mock(AddPaymentUpdateListener.class);
         mView.setAddPaymentUpdatedListener(listener);
 
@@ -378,6 +379,17 @@ public class AddCardViewUnitTest {
 
         assertThat(mView.findViewById(R.id.bt_animated_button_loading_indicator)).isVisible();
         verify(listener).onPaymentUpdated(mView);
+    }
+
+    @Test
+    public void onCardFormValid_doesNothingWhenCardFormIsValidAndCardIsNotMaxLength() {
+        AddPaymentUpdateListener listener = mock(AddPaymentUpdateListener.class);
+        mView.setAddPaymentUpdatedListener(listener);
+
+        mView.getCardForm().getCardEditText().setText(DISCOVER_19);
+
+        assertThat(mView.findViewById(R.id.bt_animated_button_loading_indicator)).isGone();
+        verifyZeroInteractions(listener);
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
### Summary of changes

 - Change auto-navigation on card entry to only auto-transition when card is valid and max length for that card type. This allows support for Discover cards 16-19 digits and aligns with [change in iOS Drop-in](https://github.com/braintree/braintree-ios-drop-in/pull/333).
 - This change requires android-card-form release with with [this PR](https://github.com/braintree/android-card-form/pull/108)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
