### PR TITLE
Handle Payment Cancellations

### DIFF
--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -1,5 +1,7 @@
 package com.braintreepayments.api
 
+import android.os.Bundle
+import android.view.View.VISIBLE
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.lifecycle.Lifecycle
@@ -236,5 +238,24 @@ class SupportedPaymentMethodsFragmentUITest {
         scenario.onFragment { fragment ->
             assertTrue(fragment.dropInViewModel.isLoading.value!!)
         }
+    }
+
+    @Test
+    fun whenStateIsRESUMED_whenUserCanceledErrorPresentInViewModel_hidesLoader() {
+        val dropInRequest = DropInRequest()
+                .vaultManager(false)
+        val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
+
+        val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        scenario.onFragment { fragment ->
+            fragment.dropInViewModel.setSupportedPaymentMethods(supportedPaymentMethods)
+            fragment.mLoadingIndicatorWrapper.visibility = VISIBLE
+            fragment.dropInViewModel.setUserCanceledError(Exception("User canceled PayPal."))
+        }
+
+        onView(withId(R.id.bt_select_payment_method_loader_wrapper)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.bt_supported_payment_methods)).check(matches(isDisplayed()))
     }
 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -428,13 +428,7 @@ public class DropInActivity extends BaseActivity {
         getDropInClient().handleThreeDSecureActivityResult(this, resultCode, data, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                if (dropInResult != null) {
-                    finishWithDropInResult(dropInResult);
-                } else if (error instanceof UserCanceledException) {
-                    dropInViewModel.setUserCanceledError(error);
-                } else {
-                    onError(error);
-                }
+                onDropInResult(dropInResult, error);
             }
         });
     }
@@ -443,13 +437,7 @@ public class DropInActivity extends BaseActivity {
         getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                if (dropInResult != null) {
-                    finishWithDropInResult(dropInResult);
-                } else if (error instanceof UserCanceledException) {
-                    dropInViewModel.setUserCanceledError(error);
-                } else {
-                    onError(error);
-                }
+                onDropInResult(dropInResult, error);
             }
         });
     }
@@ -458,15 +446,19 @@ public class DropInActivity extends BaseActivity {
         getDropInClient().handleVenmoActivityResult(this, resultCode, data, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                if (dropInResult != null) {
-                    finishWithDropInResult(dropInResult);
-                } else if (error instanceof UserCanceledException) {
-                    dropInViewModel.setUserCanceledError(error);
-                } else {
-                    onError(error);
-                }
+                onDropInResult(dropInResult, error);
             }
         });
+    }
+
+    private void onDropInResult(DropInResult dropInResult, Exception error) {
+        if (dropInResult != null) {
+            finishWithDropInResult(dropInResult);
+        } else if (error instanceof UserCanceledException) {
+            dropInViewModel.setUserCanceledError(error);
+        } else {
+            onError(error);
+        }
     }
 
     @VisibleForTesting

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -419,6 +419,8 @@ public class DropInActivity extends BaseActivity {
                 handleThreeDSecureActivityResult(resultCode, data);
             case BraintreeRequestCodes.GOOGLE_PAY:
                 handleGooglePayActivityResult(resultCode, data);
+            case BraintreeRequestCodes.VENMO:
+                handleVenmoActivityResult(resultCode, data);
         }
     }
 
@@ -439,6 +441,21 @@ public class DropInActivity extends BaseActivity {
 
     private void handleGooglePayActivityResult(int resultCode, Intent data) {
         getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
+            @Override
+            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                if (dropInResult != null) {
+                    finishWithDropInResult(dropInResult);
+                } else if (error instanceof UserCanceledException) {
+                    dropInViewModel.setUserCanceledError(error);
+                } else {
+                    onError(error);
+                }
+            }
+        });
+    }
+
+    private void handleVenmoActivityResult(int resultCode, Intent data) {
+        getDropInClient().handleVenmoActivityResult(this, resultCode, data, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
                 if (dropInResult != null) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -408,33 +408,12 @@ public class DropInActivity extends BaseActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        handleActivityResult(requestCode, resultCode, data);
-    }
-
-    private void handleActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        switch (requestCode) {
-            case BraintreeRequestCodes.THREE_D_SECURE:
-                getDropInClient().handleThreeDSecureActivityResult(this, resultCode, data, new DropInResultCallback() {
-                    @Override
-                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                        onDropInResult(dropInResult, error);
-                    }
-                });
-            case BraintreeRequestCodes.GOOGLE_PAY:
-                getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
-                    @Override
-                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                        onDropInResult(dropInResult, error);
-                    }
-                });
-            case BraintreeRequestCodes.VENMO:
-                getDropInClient().handleVenmoActivityResult(this, resultCode, data, new DropInResultCallback() {
-                    @Override
-                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                        onDropInResult(dropInResult, error);
-                    }
-                });
-        }
+        getDropInClient().handleActivityResult(this, requestCode, resultCode, data, new DropInResultCallback() {
+            @Override
+            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                onDropInResult(dropInResult, error);
+            }
+        });
     }
 
     private void onDropInResult(DropInResult dropInResult, Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -408,41 +408,33 @@ public class DropInActivity extends BaseActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+        handleActivityResult(requestCode, resultCode, data);
+    }
+
+    private void handleActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         switch (requestCode) {
             case BraintreeRequestCodes.THREE_D_SECURE:
-                handleThreeDSecureActivityResult(resultCode, data);
+                getDropInClient().handleThreeDSecureActivityResult(this, resultCode, data, new DropInResultCallback() {
+                    @Override
+                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                        onDropInResult(dropInResult, error);
+                    }
+                });
             case BraintreeRequestCodes.GOOGLE_PAY:
-                handleGooglePayActivityResult(resultCode, data);
+                getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
+                    @Override
+                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                        onDropInResult(dropInResult, error);
+                    }
+                });
             case BraintreeRequestCodes.VENMO:
-                handleVenmoActivityResult(resultCode, data);
+                getDropInClient().handleVenmoActivityResult(this, resultCode, data, new DropInResultCallback() {
+                    @Override
+                    public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                        onDropInResult(dropInResult, error);
+                    }
+                });
         }
-    }
-
-    private void handleThreeDSecureActivityResult(int resultCode, Intent data) {
-        getDropInClient().handleThreeDSecureActivityResult(this, resultCode, data, new DropInResultCallback() {
-            @Override
-            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                onDropInResult(dropInResult, error);
-            }
-        });
-    }
-
-    private void handleGooglePayActivityResult(int resultCode, Intent data) {
-        getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
-            @Override
-            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                onDropInResult(dropInResult, error);
-            }
-        });
-    }
-
-    private void handleVenmoActivityResult(int resultCode, Intent data) {
-        getDropInClient().handleVenmoActivityResult(this, resultCode, data, new DropInResultCallback() {
-            @Override
-            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                onDropInResult(dropInResult, error);
-            }
-        });
     }
 
     private void onDropInResult(DropInResult dropInResult, Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -51,13 +51,7 @@ public class DropInActivity extends BaseActivity {
         getDropInClient().deliverBrowserSwitchResult(this, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                if (dropInResult != null) {
-                    finishWithDropInResult(dropInResult);
-                } else if (error instanceof UserCanceledException) {
-                    dropInViewModel.setUserCanceledError(error);
-                } else {
-                    onError(error);
-                }
+                onDropInResult(dropInResult, error);
             }
         });
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -414,7 +414,31 @@ public class DropInActivity extends BaseActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+        switch (requestCode) {
+            case BraintreeRequestCodes.THREE_D_SECURE:
+                handleThreeDSecureActivityResult(resultCode, data);
+            case BraintreeRequestCodes.GOOGLE_PAY:
+                handleGooglePayActivityResult(resultCode, data);
+        }
+    }
+
+    private void handleThreeDSecureActivityResult(int resultCode, Intent data) {
         getDropInClient().handleThreeDSecureActivityResult(this, resultCode, data, new DropInResultCallback() {
+            @Override
+            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
+                if (dropInResult != null) {
+                    finishWithDropInResult(dropInResult);
+                } else if (error instanceof UserCanceledException) {
+                    dropInViewModel.setUserCanceledError(error);
+                } else {
+                    onError(error);
+                }
+            }
+        });
+    }
+
+    private void handleGooglePayActivityResult(int resultCode, Intent data) {
+        getDropInClient().handleGooglePayActivityResult(this, resultCode, data, new DropInResultCallback() {
             @Override
             public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
                 if (dropInResult != null) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -249,6 +249,15 @@ public class DropInClient {
         });
     }
 
+    void handleVenmoActivityResult(final FragmentActivity activity, int resultCode, Intent data, final DropInResultCallback callback) {
+        venmoClient.onActivityResult(activity, resultCode, data, new VenmoOnActivityResultCallback() {
+            @Override
+            public void onResult(@Nullable VenmoAccountNonce venmoAccountNonce, @Nullable Exception error) {
+                notifyDropInResult(activity, venmoAccountNonce, error, callback);
+            }
+        });
+    }
+
     private void notifyDropInResult(FragmentActivity activity, PaymentMethodNonce paymentMethodNonce, Exception dropInResultError, final DropInResultCallback callback) {
         if (dropInResultError != null) {
             callback.onResult(null, dropInResultError);

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -227,6 +227,20 @@ public class DropInClient {
         }
     }
 
+    void handleActivityResult(FragmentActivity activity, int requestCode, int resultCode, @Nullable Intent data, DropInResultCallback callback) {
+        switch (requestCode) {
+            case BraintreeRequestCodes.THREE_D_SECURE:
+                handleThreeDSecureActivityResult(activity, resultCode, data, callback);
+                return;
+            case BraintreeRequestCodes.GOOGLE_PAY:
+                handleGooglePayActivityResult(activity, resultCode, data, callback);
+                return;
+            case BraintreeRequestCodes.VENMO:
+                handleVenmoActivityResult(activity, resultCode, data, callback);
+                return;
+        }
+    }
+
     void handleThreeDSecureActivityResult(final FragmentActivity activity, int resultCode, Intent data, final DropInResultCallback callback) {
         threeDSecureClient.onActivityResult(resultCode, data, new ThreeDSecureResultCallback() {
             @Override

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -240,7 +240,6 @@ public class DropInClient {
         });
     }
 
-    // TODO: unit test
     void handleGooglePayActivityResult(final FragmentActivity activity, int resultCode, Intent data, final DropInResultCallback callback) {
         googlePayClient.onActivityResult(resultCode, data, new GooglePayOnActivityResultCallback() {
             @Override

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -240,6 +240,16 @@ public class DropInClient {
         });
     }
 
+    // TODO: unit test
+    void handleGooglePayActivityResult(final FragmentActivity activity, int resultCode, Intent data, final DropInResultCallback callback) {
+        googlePayClient.onActivityResult(resultCode, data, new GooglePayOnActivityResultCallback() {
+            @Override
+            public void onResult(@Nullable PaymentMethodNonce paymentMethodNonce, @Nullable Exception error) {
+               notifyDropInResult(activity, paymentMethodNonce, error, callback);
+            }
+        });
+    }
+
     private void notifyDropInResult(FragmentActivity activity, PaymentMethodNonce paymentMethodNonce, Exception dropInResultError, final DropInResultCallback callback) {
         if (dropInResultError != null) {
             callback.onResult(null, dropInResultError);

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -24,7 +24,9 @@ import java.util.List;
 
 public class SupportedPaymentMethodsFragment extends Fragment implements SupportedPaymentMethodSelectedListener, VaultedPaymentMethodSelectedListener {
 
-    private View mLoadingIndicatorWrapper;
+    @VisibleForTesting
+    View mLoadingIndicatorWrapper;
+
     private TextView mSupportedPaymentMethodsHeader;
 
     @VisibleForTesting

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -5,10 +5,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DividerItemDecoration;
@@ -99,6 +101,13 @@ public class SupportedPaymentMethodsFragment extends Fragment implements Support
                 } else {
                     hideLoader();
                 }
+            }
+        });
+
+        dropInViewModel.getUserCanceledError().observe(getViewLifecycleOwner(), new Observer<Exception>() {
+            @Override
+            public void onChanged(Exception e) {
+                hideLoader();
             }
         });
 

--- a/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockDropInClientBuilder.java
+++ b/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockDropInClientBuilder.java
@@ -40,6 +40,8 @@ public class MockDropInClientBuilder {
     private DropInResult handleThreeDSecureActivityResultSuccess;
     private Exception deliverBrowserSwitchResultError;
     private DropInResult deliverBrowserSwitchResultSuccess;
+    private Exception handleActivityResultError;
+    private DropInResult handleActivityResultSuccess;
 
     private boolean shouldPerformThreeDSecureVerification;
 
@@ -150,6 +152,16 @@ public class MockDropInClientBuilder {
 
     MockDropInClientBuilder deliverBrowserSwitchResultSuccess(DropInResult result) {
         this.deliverBrowserSwitchResultSuccess = result;
+        return this;
+    }
+
+    MockDropInClientBuilder handleActivityResultError(Exception error) {
+        this.handleActivityResultError = error;
+        return this;
+    }
+
+    MockDropInClientBuilder handleActivityResultSuccess(DropInResult result) {
+        this.handleActivityResultSuccess = result;
         return this;
     }
 
@@ -313,6 +325,19 @@ public class MockDropInClientBuilder {
                 return null;
             }
         }).when(dropInClient).deliverBrowserSwitchResult(any(FragmentActivity.class), any(DropInResultCallback.class));
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                DropInResultCallback callback = (DropInResultCallback) invocation.getArguments()[4];
+                if (handleActivityResultError != null) {
+                    callback.onResult(null, handleActivityResultError);
+                } else if (handleActivityResultSuccess != null) {
+                    callback.onResult(handleActivityResultSuccess, null);
+                }
+                return null;
+            }
+        }).when(dropInClient).handleActivityResult(any(FragmentActivity.class), anyInt(), anyInt(), any(Intent.class), any(DropInResultCallback.class));
 
         return dropInClient;
     }

--- a/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockGooglePayClientBuilder.java
+++ b/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockGooglePayClientBuilder.java
@@ -1,11 +1,14 @@
 package com.braintreepayments.api;
 
+import android.content.Intent;
+
 import androidx.fragment.app.FragmentActivity;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -13,6 +16,8 @@ public class MockGooglePayClientBuilder {
 
     private Boolean isReadyToPaySuccess;
     private Exception isReadyToPayError;
+    private PaymentMethodNonce onActivityResultSuccess;
+    private Exception onActivityResultError;
 
     public MockGooglePayClientBuilder isReadyToPaySuccess(boolean isReadyToPay) {
         isReadyToPaySuccess = isReadyToPay;
@@ -21,6 +26,16 @@ public class MockGooglePayClientBuilder {
 
     public MockGooglePayClientBuilder isReadyToPayError(Exception error) {
         isReadyToPayError = error;
+        return this;
+    }
+
+    public MockGooglePayClientBuilder onActivityResultSuccess(PaymentMethodNonce paymentMethodNonce) {
+        onActivityResultSuccess = paymentMethodNonce;
+        return this;
+    }
+
+    public MockGooglePayClientBuilder onActivityResultError(Exception error) {
+        onActivityResultError = error;
         return this;
     }
 
@@ -40,6 +55,18 @@ public class MockGooglePayClientBuilder {
             }
         }).when(googlePayClient).isReadyToPay(any(FragmentActivity.class), any(GooglePayIsReadyToPayCallback.class));
 
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                GooglePayOnActivityResultCallback callback = (GooglePayOnActivityResultCallback) invocation.getArguments()[2];
+                if (onActivityResultSuccess != null) {
+                    callback.onResult(onActivityResultSuccess, null);
+                } else if (onActivityResultError != null) {
+                    callback.onResult(null, onActivityResultError);
+                }
+                return null;
+            }
+        }).when(googlePayClient).onActivityResult(anyInt(), any(Intent.class), any(GooglePayOnActivityResultCallback.class));
         return googlePayClient;
     }
 }

--- a/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockVenmoClientBuilder.java
+++ b/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockVenmoClientBuilder.java
@@ -1,0 +1,47 @@
+package com.braintreepayments.api;
+
+import android.content.Intent;
+
+import androidx.fragment.app.FragmentActivity;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class MockVenmoClientBuilder {
+
+    private VenmoAccountNonce onActivityResultSuccess;
+    private Exception onActivityResultError;
+
+    public MockVenmoClientBuilder onActivityResultSuccess(VenmoAccountNonce venmoAccountNonce) {
+        onActivityResultSuccess = venmoAccountNonce;
+        return this;
+    }
+
+    public MockVenmoClientBuilder onActivityResultError(Exception error) {
+        onActivityResultError = error;
+        return this;
+    }
+
+    public VenmoClient build() {
+        VenmoClient venmoClient = mock(VenmoClient.class);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                VenmoOnActivityResultCallback callback = (VenmoOnActivityResultCallback) invocation.getArguments()[3];
+                if (onActivityResultSuccess != null) {
+                    callback.onResult(onActivityResultSuccess, null);
+                } else if (onActivityResultError != null) {
+                    callback.onResult(null, onActivityResultError);
+                }
+                return null;
+            }
+        }).when(venmoClient).onActivityResult(any(FragmentActivity.class), anyInt(), any(Intent.class), any(VenmoOnActivityResultCallback.class));
+        return venmoClient;
+    }
+}

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -149,22 +149,6 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    public void onActivityResult_handlesThreeDSecureActivityResult() {
-        String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
-
-        DropInClient dropInClient = mock(DropInClient.class);
-
-        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
-        mActivityController.setup();
-
-        Intent intent = mock(Intent.class);
-        mActivity.onActivityResult(13487, 1, intent);
-
-        verify(dropInClient).handleThreeDSecureActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
-    }
-
-    @Test
     public void onActivityResult_whenDropInResultExists_finishesActivity() {
         String authorization = Fixtures.TOKENIZATION_KEY;
         DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
@@ -180,7 +164,7 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(13487, 1, mock(Intent.class));
+        mActivity.onActivityResult(BraintreeRequestCodes.THREE_D_SECURE, 1, mock(Intent.class));
         assertTrue(mActivity.isFinishing());
     }
 
@@ -197,7 +181,7 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(13487, 1, mock(Intent.class));
+        mActivity.onActivityResult(BraintreeRequestCodes.THREE_D_SECURE, 1, mock(Intent.class));
 
         assertFalse(mActivity.isFinishing());
         assertEquals(error, mActivity.dropInViewModel.getUserCanceledError().getValue());
@@ -216,10 +200,61 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(13487, 1, mock(Intent.class));
+        mActivity.onActivityResult(BraintreeRequestCodes.THREE_D_SECURE, 1, mock(Intent.class));
 
         assertTrue(mActivity.isFinishing());
         verify(mActivity.dropInClient).sendAnalyticsEvent("sdk.exit.sdk-error");
+    }
+
+    @Test
+    public void onActivityResult_whenResultCodeThreeDSecure_handlesThreeDSecureResult() {
+        String authorization = Fixtures.TOKENIZATION_KEY;
+        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+
+        DropInClient dropInClient = new MockDropInClientBuilder()
+                .build();
+
+        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
+        mActivityController.setup();
+
+        Intent intent = mock(Intent.class);
+        mActivity.onActivityResult(BraintreeRequestCodes.THREE_D_SECURE, 1, intent);
+
+        verify(mActivity.dropInClient).handleThreeDSecureActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
+    }
+
+    @Test
+    public void onActivityResult_whenResultCodeVenmo_handlesVenmoResult() {
+        String authorization = Fixtures.TOKENIZATION_KEY;
+        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+
+        DropInClient dropInClient = new MockDropInClientBuilder()
+                .build();
+
+        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
+        mActivityController.setup();
+
+        Intent intent = mock(Intent.class);
+        mActivity.onActivityResult(BraintreeRequestCodes.VENMO, 1, intent);
+
+        verify(mActivity.dropInClient).handleVenmoActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
+    }
+
+    @Test
+    public void onActivityResult_whenResultCodeGooglePay_handlesGooglePayResult() {
+        String authorization = Fixtures.TOKENIZATION_KEY;
+        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+
+        DropInClient dropInClient = new MockDropInClientBuilder()
+                .build();
+
+        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
+        mActivityController.setup();
+
+        Intent intent = mock(Intent.class);
+        mActivity.onActivityResult(BraintreeRequestCodes.GOOGLE_PAY, 1, intent);
+
+        verify(mActivity.dropInClient).handleGooglePayActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -159,7 +159,7 @@ public class DropInActivityUnitTest {
         mActivityController.setup();
 
         Intent intent = mock(Intent.class);
-        mActivity.onActivityResult(100, 1, intent);
+        mActivity.onActivityResult(13487, 1, intent);
 
         verify(dropInClient).handleThreeDSecureActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
     }
@@ -180,7 +180,7 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(100, 1, mock(Intent.class));
+        mActivity.onActivityResult(13487, 1, mock(Intent.class));
         assertTrue(mActivity.isFinishing());
     }
 
@@ -197,7 +197,7 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(100, 1, mock(Intent.class));
+        mActivity.onActivityResult(13487, 1, mock(Intent.class));
 
         assertFalse(mActivity.isFinishing());
         assertEquals(error, mActivity.dropInViewModel.getUserCanceledError().getValue());
@@ -216,7 +216,7 @@ public class DropInActivityUnitTest {
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
-        mActivity.onActivityResult(100, 1, mock(Intent.class));
+        mActivity.onActivityResult(13487, 1, mock(Intent.class));
 
         assertTrue(mActivity.isFinishing());
         verify(mActivity.dropInClient).sendAnalyticsEvent("sdk.exit.sdk-error");

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -158,7 +158,7 @@ public class DropInActivityUnitTest {
         when(result.getPaymentMethodNonce()).thenReturn(nonce);
         when(result.getDeviceData()).thenReturn("device data");
         DropInClient dropInClient = new MockDropInClientBuilder()
-                .handleThreeDSecureActivityResultSuccess(result)
+                .handleActivityResultSuccess(result)
                 .build();
 
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
@@ -175,7 +175,7 @@ public class DropInActivityUnitTest {
 
         Exception error = new UserCanceledException("User canceled 3DS.");
         DropInClient dropInClient = new MockDropInClientBuilder()
-                .handleThreeDSecureActivityResultError(error)
+                .handleActivityResultError(error)
                 .build();
 
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
@@ -194,7 +194,7 @@ public class DropInActivityUnitTest {
 
         Exception error = new Exception("A 3DS error");
         DropInClient dropInClient = new MockDropInClientBuilder()
-                .handleThreeDSecureActivityResultError(error)
+                .handleActivityResultError(error)
                 .build();
 
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
@@ -207,7 +207,7 @@ public class DropInActivityUnitTest {
     }
 
     @Test
-    public void onActivityResult_whenResultCodeThreeDSecure_handlesThreeDSecureResult() {
+    public void onActivityResult_forwardsResultToDropInClient() {
         String authorization = Fixtures.TOKENIZATION_KEY;
         DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
 
@@ -220,41 +220,7 @@ public class DropInActivityUnitTest {
         Intent intent = mock(Intent.class);
         mActivity.onActivityResult(BraintreeRequestCodes.THREE_D_SECURE, 1, intent);
 
-        verify(mActivity.dropInClient).handleThreeDSecureActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
-    }
-
-    @Test
-    public void onActivityResult_whenResultCodeVenmo_handlesVenmoResult() {
-        String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
-
-        DropInClient dropInClient = new MockDropInClientBuilder()
-                .build();
-
-        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
-        mActivityController.setup();
-
-        Intent intent = mock(Intent.class);
-        mActivity.onActivityResult(BraintreeRequestCodes.VENMO, 1, intent);
-
-        verify(mActivity.dropInClient).handleVenmoActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
-    }
-
-    @Test
-    public void onActivityResult_whenResultCodeGooglePay_handlesGooglePayResult() {
-        String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
-
-        DropInClient dropInClient = new MockDropInClientBuilder()
-                .build();
-
-        setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
-        mActivityController.setup();
-
-        Intent intent = mock(Intent.class);
-        mActivity.onActivityResult(BraintreeRequestCodes.GOOGLE_PAY, 1, intent);
-
-        verify(mActivity.dropInClient).handleGooglePayActivityResult(same(mActivity), eq(1), same(intent), any(DropInResultCallback.class));
+        verify(mActivity.dropInClient).handleActivityResult(same(mActivity), eq(BraintreeRequestCodes.THREE_D_SECURE), eq(1), same(intent), any(DropInResultCallback.class));
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -1676,6 +1676,63 @@ public class DropInClientUnitTest {
     }
 
     @Test
+    public void onActivityResult_whenResultCodeVenmo_handlesVenmoResult() {
+        VenmoClient venmoClient = mock(VenmoClient.class);
+
+        DropInRequest dropInRequest = new DropInRequest();
+        DropInClientParams params = new DropInClientParams()
+                .dropInRequest(dropInRequest)
+                .venmoClient(venmoClient);
+
+        DropInClient sut = new DropInClient(params);
+
+        FragmentActivity activity = mock(FragmentActivity.class);
+        Intent intent = mock(Intent.class);
+        DropInResultCallback callback = mock(DropInResultCallback.class);
+        sut.handleActivityResult(activity, BraintreeRequestCodes.VENMO, 1, intent, callback);
+
+        verify(venmoClient).onActivityResult(same(activity), eq(1), same(intent), any(VenmoOnActivityResultCallback.class));
+    }
+
+    @Test
+    public void onActivityResult_whenResultCodeGooglePay_handlesGooglePayResult() {
+        GooglePayClient googlePayClient = mock(GooglePayClient.class);
+
+        DropInRequest dropInRequest = new DropInRequest();
+        DropInClientParams params = new DropInClientParams()
+                .dropInRequest(dropInRequest)
+                .googlePayClient(googlePayClient);
+
+        DropInClient sut = new DropInClient(params);
+
+        FragmentActivity activity = mock(FragmentActivity.class);
+        Intent intent = mock(Intent.class);
+        DropInResultCallback callback = mock(DropInResultCallback.class);
+        sut.handleActivityResult(activity, BraintreeRequestCodes.GOOGLE_PAY, 1, intent, callback);
+
+        verify(googlePayClient).onActivityResult(eq(1), same(intent), any(GooglePayOnActivityResultCallback.class));
+    }
+
+    @Test
+    public void onActivityResult_whenResultCodeThreeDSecure_handlesThreeDSecureResult() {
+        ThreeDSecureClient threeDSecureClient = mock(ThreeDSecureClient.class);
+
+        DropInRequest dropInRequest = new DropInRequest();
+        DropInClientParams params = new DropInClientParams()
+                .dropInRequest(dropInRequest)
+                .threeDSecureClient(threeDSecureClient);
+
+        DropInClient sut = new DropInClient(params);
+
+        FragmentActivity activity = mock(FragmentActivity.class);
+        Intent intent = mock(Intent.class);
+        DropInResultCallback callback = mock(DropInResultCallback.class);
+        sut.handleActivityResult(activity, BraintreeRequestCodes.THREE_D_SECURE, 1, intent, callback);
+
+        verify(threeDSecureClient).onActivityResult(eq(1), same(intent), any(ThreeDSecureResultCallback.class));
+    }
+
+    @Test
     public void handleGooglePayActivityResult_withPaymentMethodNonce_callsBackDropInResult() {
         PaymentMethodNonce paymentMethodNonce = mock(PaymentMethodNonce.class);
         GooglePayClient googlePayClient = new MockGooglePayClientBuilder()

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -1682,15 +1682,10 @@ public class DropInClientUnitTest {
                 .onActivityResultSuccess(paymentMethodNonce)
                 .build();
 
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(mockConfiguration(true, true, true, true, true))
-                .build();
-
         DropInRequest dropInRequest = new DropInRequest();
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
-                .googlePayClient(googlePayClient)
-                .braintreeClient(braintreeClient);
+                .googlePayClient(googlePayClient);
 
         DropInClient sut = new DropInClient(params);
 
@@ -1712,21 +1707,62 @@ public class DropInClientUnitTest {
                 .onActivityResultError(error)
                 .build();
 
-        BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
-                .configuration(mockConfiguration(true, true, true, true, true))
-                .build();
-
         DropInRequest dropInRequest = new DropInRequest();
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
-                .googlePayClient(googlePayClient)
-                .braintreeClient(braintreeClient);
+                .googlePayClient(googlePayClient);
 
         DropInClient sut = new DropInClient(params);
 
         Intent data = mock(Intent.class);
         DropInResultCallback callback = mock(DropInResultCallback.class);
         sut.handleGooglePayActivityResult(activity, 1, data, callback);
+
+        verify(callback).onResult((DropInResult) isNull(), same(error));
+    }
+
+    @Test
+    public void handleVenmoActivityResult_withVenmoAccountNonce_callsBackDropInResult() {
+        VenmoAccountNonce venmoAccountNonce = mock(VenmoAccountNonce.class);
+        VenmoClient venmoClient = new MockVenmoClientBuilder()
+                .onActivityResultSuccess(venmoAccountNonce)
+                .build();
+
+        DropInRequest dropInRequest = new DropInRequest();
+        DropInClientParams params = new DropInClientParams()
+                .dropInRequest(dropInRequest)
+                .venmoClient(venmoClient);
+
+        DropInClient sut = new DropInClient(params);
+
+        Intent data = mock(Intent.class);
+        DropInResultCallback callback = mock(DropInResultCallback.class);
+        sut.handleVenmoActivityResult(activity, 1, data, callback);
+
+        ArgumentCaptor<DropInResult> captor = ArgumentCaptor.forClass(DropInResult.class);
+        verify(callback).onResult(captor.capture(), (Exception) isNull());
+
+        DropInResult result = captor.getValue();
+        assertEquals(venmoAccountNonce, result.getPaymentMethodNonce());
+    }
+
+    @Test
+    public void handleVenmoActivityResult_withVenmoError_callsBackError() {
+        Exception error = new Exception("Venmo error");
+        VenmoClient venmoClient = new MockVenmoClientBuilder()
+                .onActivityResultError(error)
+                .build();
+
+        DropInRequest dropInRequest = new DropInRequest();
+        DropInClientParams params = new DropInClientParams()
+                .dropInRequest(dropInRequest)
+                .venmoClient(venmoClient);
+
+        DropInClient sut = new DropInClient(params);
+
+        Intent data = mock(Intent.class);
+        DropInResultCallback callback = mock(DropInResultCallback.class);
+        sut.handleVenmoActivityResult(activity, 1, data, callback);
 
         verify(callback).onResult((DropInResult) isNull(), same(error));
     }


### PR DESCRIPTION
### Summary of changes

 - Handle Activity results for PayPal, GooglePay, and Venmo flows
 - Remove loading indicator and display supported payment methods in `SupportedPaymentMethodsFragment` on user cancellation 

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
