### PR TITLE
Handle Browser Switch Results Internally

### DIFF
--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -21,12 +21,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <data android:scheme="${applicationId}.braintree" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
         </activity>
         <activity android:name=".SettingsActivity" android:label="@string/options" />
         <activity android:name=".CreateTransactionActivity" />

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -8,11 +8,9 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
 
 import com.braintreepayments.api.CardNonce;
-import com.braintreepayments.api.DropInResultCallback;
 import com.braintreepayments.api.DropInActivity;
 import com.braintreepayments.api.DropInClient;
 import com.braintreepayments.api.DropInRequest;
@@ -216,17 +214,6 @@ public class MainActivity extends BaseActivity {
                     handleDropInResult(dropInResult);
                 } else {
                     mAddPaymentMethodButton.setVisibility(VISIBLE);
-                }
-            }
-        });
-
-        dropInClient.deliverBrowserSwitchResult(this, new DropInResultCallback() {
-            @Override
-            public void onResult(@Nullable DropInResult dropInResult, @Nullable Exception error) {
-                if (dropInResult != null) {
-                    handleDropInResult(dropInResult);
-                } else {
-                    onError(error);
                 }
             }
         });

--- a/Drop-In/src/main/AndroidManifest.xml
+++ b/Drop-In/src/main/AndroidManifest.xml
@@ -10,7 +10,14 @@
         tools:ignore="UnusedAttribute">
 
         <activity android:name="com.braintreepayments.api.DropInActivity"
-            android:theme="@style/bt_drop_in_activity_theme"/>
+            android:theme="@style/bt_drop_in_activity_theme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="${applicationId}.braintree" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/Drop-In/src/main/AndroidManifest.xml
+++ b/Drop-In/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         tools:ignore="UnusedAttribute">
 
         <activity android:name="com.braintreepayments.api.DropInActivity"
-            android:theme="@style/bt_drop_in_activity_theme">
+            android:theme="@style/bt_drop_in_activity_theme"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="${applicationId}.braintree" />

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -57,6 +57,12 @@ public class DropInActivity extends BaseActivity {
     }
 
     @Override
+    protected void onNewIntent(Intent newIntent) {
+        super.onNewIntent(newIntent);
+        setIntent(newIntent);
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.bt_drop_in_activity);


### PR DESCRIPTION
### Summary of changes

 - Move the `intent-filter` for handling browser switch results off the merchant (demo) app `ActivityManifest` and into DropIn `ActivityManifest`.
 - Add `launchMode=singleTop` to `DropInActivity` to return to the same activity instance after browser switching

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
