### PR TITLE
Add Migration Guide & Update DropInRequest for Migration Guide Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * Change `DropInPaymentMethodType#getCardTypes()` parameter from `Set` to `List`
   * Replace `VaultManagerActivity` with `VaultManagerFragment`
   * Remove `clientToken` and `tokenizationKey` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
+  * Remove deprecated `amount` parameter from `DropInRequest`
   * Replace `DropInActivity.EXTRA_ERROR` with `DropInResult.EXTRA_ERROR`
 
 **Note:** The credentials for integrating with 3DS have changed. If you are using 3DS please update the credentials in your app-level `build.gradle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
   * Replace `VaultManagerActivity` with `VaultManagerFragment`
   * Remove `clientToken` and `tokenizationKey` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
   * Remove deprecated `amount` parameter from `DropInRequest`
+  * Remove `intent` from `DropInRequest`
+  * Remove builder pattern from `DropInRequest`
+  * Update `DropInRequest` getter and setter methods to follow consistent naming for Kotlin synthesized properties
   * Replace `DropInActivity.EXTRA_ERROR` with `DropInResult.EXTRA_ERROR`
 
 **Note:** The credentials for integrating with 3DS have changed. If you are using 3DS please update the credentials in your app-level `build.gradle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * Change `DropInPaymentMethodType#getCardTypes()` parameter from `Set` to `List`
   * Replace `VaultManagerActivity` with `VaultManagerFragment`
   * Remove `clientToken` and `tokenizationKey` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
+  * Replace `DropInActivity.EXTRA_ERROR` with `DropInResult.EXTRA_ERROR`
 
 **Note:** The credentials for integrating with 3DS have changed. If you are using 3DS please update the credentials in your app-level `build.gradle`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   * Remove `EditCardView`
   * Change `DropInPaymentMethodType#getCardTypes()` parameter from `Set` to `List`
   * Replace `VaultManagerActivity` with `VaultManagerFragment`
-  * Remove `clientToken` and `tokenizationKey` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
+  * Remove `clientToken`, `tokenizationKey`, and `authorization` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
   * Remove deprecated `amount` parameter from `DropInRequest`
   * Remove `intent` from `DropInRequest`
   * Remove builder pattern from `DropInRequest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   * Remove `EditCardView`
   * Change `DropInPaymentMethodType#getCardTypes()` parameter from `Set` to `List`
   * Replace `VaultManagerActivity` with `VaultManagerFragment`
+  * Remove `clientToken` and `tokenizationKey` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
 
 **Note:** The credentials for integrating with 3DS have changed. If you are using 3DS please update the credentials in your app-level `build.gradle`
 

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -190,19 +190,19 @@ public class MainActivity extends BaseActivity {
 
     @Override
     protected void onAuthorizationFetched() {
-        DropInRequest dropInRequest = new DropInRequest()
-                .requestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this))
-                .collectDeviceData(Settings.shouldCollectDeviceData(this))
-                .googlePaymentRequest(getGooglePaymentRequest())
-                .maskCardNumber(true)
-                .maskSecurityCode(true)
-                .allowVaultCardOverride(Settings.isSaveCardCheckBoxVisible(this))
-                .vaultCard(Settings.defaultVaultSetting(this))
-                .vaultManager(Settings.isVaultManagerEnabled(this))
-                .cardholderNameStatus(Settings.getCardholderNameStatus(this));
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldRequestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this));
+        dropInRequest.setShouldCollectDeviceData(Settings.shouldCollectDeviceData(this));
+        dropInRequest.setGooglePayRequest(getGooglePaymentRequest());
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setAllowVaultCardOverride(Settings.isSaveCardCheckBoxVisible(this));
+        dropInRequest.setVaultCardDefaultValue(Settings.defaultVaultSetting(this));
+        dropInRequest.setEnableVaultManager(Settings.isVaultManagerEnabled(this));
+        dropInRequest.setCardholderNameStatus(Settings.getCardholderNameStatus(this));
 
         if (Settings.isThreeDSecureEnabled(this)) {
-            dropInRequest.threeDSecureRequest(demoThreeDSecureRequest());
+            dropInRequest.setThreeDSecureRequest(demoThreeDSecureRequest());
         }
 
         dropInClient = new DropInClient(this, mAuthorization, dropInRequest);

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -191,7 +191,6 @@ public class MainActivity extends BaseActivity {
     @Override
     protected void onAuthorizationFetched() {
         DropInRequest dropInRequest = new DropInRequest()
-                .clientToken(mAuthorization)
                 .requestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this))
                 .collectDeviceData(Settings.shouldCollectDeviceData(this))
                 .googlePaymentRequest(getGooglePaymentRequest())

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -194,8 +194,8 @@ public class MainActivity extends BaseActivity {
         dropInRequest.setShouldRequestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this));
         dropInRequest.setShouldCollectDeviceData(Settings.shouldCollectDeviceData(this));
         dropInRequest.setGooglePayRequest(getGooglePaymentRequest());
-        dropInRequest.setMaskCardNumber(true);
-        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setShouldMaskCardNumber(true);
+        dropInRequest.setShouldMaskSecurityCode(true);
         dropInRequest.setAllowVaultCardOverride(Settings.isSaveCardCheckBoxVisible(this));
         dropInRequest.setVaultCardDefaultValue(Settings.defaultVaultSetting(this));
         dropInRequest.setEnableVaultManager(Settings.isVaultManagerEnabled(this));

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -11,7 +11,6 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 
 import com.braintreepayments.api.CardNonce;
-import com.braintreepayments.api.DropInActivity;
 import com.braintreepayments.api.DropInClient;
 import com.braintreepayments.api.DropInRequest;
 import com.braintreepayments.api.DropInResult;
@@ -191,14 +190,14 @@ public class MainActivity extends BaseActivity {
     @Override
     protected void onAuthorizationFetched() {
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldRequestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this));
-        dropInRequest.setShouldCollectDeviceData(Settings.shouldCollectDeviceData(this));
+        dropInRequest.setRequestThreeDSecureVerification(Settings.isThreeDSecureEnabled(this));
+        dropInRequest.setCollectDeviceData(Settings.shouldCollectDeviceData(this));
         dropInRequest.setGooglePayRequest(getGooglePaymentRequest());
-        dropInRequest.setShouldMaskCardNumber(true);
-        dropInRequest.setShouldMaskSecurityCode(true);
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
         dropInRequest.setAllowVaultCardOverride(Settings.isSaveCardCheckBoxVisible(this));
         dropInRequest.setVaultCardDefaultValue(Settings.defaultVaultSetting(this));
-        dropInRequest.setEnableVaultManager(Settings.isVaultManagerEnabled(this));
+        dropInRequest.setVaultManagerEnabled(Settings.isVaultManagerEnabled(this));
         dropInRequest.setCardholderNameStatus(Settings.getCardholderNameStatus(this));
 
         if (Settings.isThreeDSecureEnabled(this)) {

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -174,7 +174,7 @@ public class MainActivity extends BaseActivity {
             mPurchaseButton.setEnabled(true);
         } else if (resultCode != RESULT_CANCELED) {
             safelyCloseLoadingView();
-            showDialog(((Exception) data.getSerializableExtra(DropInActivity.EXTRA_ERROR))
+            showDialog(((Exception) data.getSerializableExtra(DropInResult.EXTRA_ERROR))
                     .getMessage());
         }
     }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -136,5 +136,7 @@ class AddCardFragmentUITest {
         }
 
         onView(withId(R.id.bt_button)).check(matches(isDisplayed()))
+
+        val dropInRequest = DropInRequest()
     }
 }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -136,7 +136,5 @@ class AddCardFragmentUITest {
         }
 
         onView(withId(R.id.bt_button)).check(matches(isDisplayed()))
-
-        val dropInRequest = DropInRequest()
     }
 }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
@@ -34,7 +34,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_buttonTextIsAddCard() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -47,7 +47,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_expirationDateFieldIsFocused() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -59,7 +59,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_displaysCVVAndPostalCodeWhenPresentInConfiguration() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(true, true))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -74,7 +74,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_hidesCVVandPostalCodeWhenNotPresentInConfiguration() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -89,7 +89,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenDropInRequestRequiresCardholderName_setsCardFormsCardholderNameToRequired() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).cardholderNameStatus(FIELD_REQUIRED))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(FIELD_REQUIRED))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -111,7 +111,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenDropInCardholderNameFieldDisabled_saveCardCheckboxCheckedAndHidden() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -126,9 +126,11 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrueAndTokenizationKey_hidesSaveCardCheckbox() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().tokenizationKey(Fixtures.TOKENIZATION_KEY).allowVaultCardOverride(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
+        args.putBoolean("EXTRA_AUTH_IS_TOKENIZATION_KEY", true)
+
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
@@ -140,7 +142,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_showsSaveCardCheckbox() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).allowVaultCardOverride(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -154,7 +156,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideFalse_showsSaveCardCheckbox() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).allowVaultCardOverride(false))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(false))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -168,7 +170,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_andVaultCardTrue_showsSaveCardCheckboxChecked() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).allowVaultCardOverride(true).vaultCard(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true).vaultCard(true))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -183,7 +185,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_andVaultCardFalse_showsSaveCardCheckboxNotChecked() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).allowVaultCardOverride(true).vaultCard(false))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true).vaultCard(false))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -198,7 +200,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardNumberFieldFocus_returnsToAddCardFragment() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -224,7 +226,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_sendsCardDetailsEvent() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -251,7 +253,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenCardFormNotValid_doesNotSendCardDetailsEventAndShowsButton() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -276,7 +278,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenOptionalCardholderNameFieldIsEmpty_sendsCardDetailsEventWithoutCardholderName() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).cardholderNameStatus(CardForm.FIELD_OPTIONAL))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(CardForm.FIELD_OPTIONAL))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -306,7 +308,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenOptionalCardholderNameFieldIsFilled_sendsCardDetailsEventWithCardholderName() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).cardholderNameStatus(CardForm.FIELD_OPTIONAL))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(CardForm.FIELD_OPTIONAL))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -337,7 +339,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenCardholderNameRequired_sendsCardDetailsEventWithCardholderName() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN).cardholderNameStatus(FIELD_REQUIRED))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(FIELD_REQUIRED))
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -368,7 +370,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenCardValidationErrorsArePresentInViewModel_displaysErrorsInlineToUser() {
             val args = Bundle()
-            args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+            args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
             args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(true, true))
             args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -390,7 +392,7 @@ class CardDetailsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenUserCanceledErrorPresentInViewModel_showsSubmitButtonAgain() {
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().clientToken(Fixtures.CLIENT_TOKEN))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(true, true))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
@@ -2,7 +2,6 @@ package com.braintreepayments.api
 
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.core.view.isVisible
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso.onView
@@ -13,12 +12,12 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import com.braintreepayments.api.CardNumber.VISA
 import com.braintreepayments.api.dropin.R
 import com.braintreepayments.cardform.view.CardForm
+import com.braintreepayments.cardform.view.CardForm.FIELD_OPTIONAL
 import com.braintreepayments.cardform.view.CardForm.FIELD_REQUIRED
 import junit.framework.TestCase.*
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
-import org.mockito.internal.matchers.Not
 import java.util.concurrent.CountDownLatch
 
 
@@ -88,8 +87,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_whenDropInRequestRequiresCardholderName_setsCardFormsCardholderNameToRequired() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_REQUIRED
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(FIELD_REQUIRED))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -125,8 +126,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrueAndTokenizationKey_hidesSaveCardCheckbox() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.allowVaultCardOverride = true
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         args.putBoolean("EXTRA_AUTH_IS_TOKENIZATION_KEY", true)
@@ -141,8 +144,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_showsSaveCardCheckbox() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.allowVaultCardOverride = true
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -155,8 +160,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideFalse_showsSaveCardCheckbox() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.allowVaultCardOverride = false
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(false))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -169,8 +176,11 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_andVaultCardTrue_showsSaveCardCheckboxChecked() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.allowVaultCardOverride = true
+        dropInRequest.vaultCardDefaultValue = true
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true).vaultCard(true))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -184,8 +194,11 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_withAllowVaultCardOverrideTrue_andVaultCardFalse_showsSaveCardCheckboxNotChecked() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.allowVaultCardOverride = true
+        dropInRequest.vaultCardDefaultValue = false
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().allowVaultCardOverride(true).vaultCard(false))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
@@ -277,8 +290,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenOptionalCardholderNameFieldIsEmpty_sendsCardDetailsEventWithoutCardholderName() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_OPTIONAL
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(CardForm.FIELD_OPTIONAL))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -307,8 +322,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenOptionalCardholderNameFieldIsFilled_sendsCardDetailsEventWithCardholderName() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_OPTIONAL
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(CardForm.FIELD_OPTIONAL))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -338,8 +355,10 @@ class CardDetailsFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onCardFormSubmit_whenCardholderNameRequired_sendsCardDetailsEventWithCardholderName() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_REQUIRED
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest().cardholderNameStatus(FIELD_REQUIRED))
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/DropInActivityUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/DropInActivityUITest.kt
@@ -21,7 +21,6 @@ class DropInActivityUITest {
         // TODO: Investigate mockito failures in androidTest and figure out a DropInClient dependency injection strategy for unit tests
         val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
         val dropInRequest = DropInRequest()
-                .clientToken(authorization.toString())
                 .threeDSecureRequest(ThreeDSecureRequest())
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -52,7 +51,6 @@ class DropInActivityUITest {
     fun whenStateIsRESUMED_onCancelDropInEvent_finishesWithResult() {
         val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
         val dropInRequest = DropInRequest()
-                .clientToken(authorization.toString())
                 .threeDSecureRequest(ThreeDSecureRequest())
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/DropInActivityUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/DropInActivityUITest.kt
@@ -21,7 +21,7 @@ class DropInActivityUITest {
         // TODO: Investigate mockito failures in androidTest and figure out a DropInClient dependency injection strategy for unit tests
         val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
         val dropInRequest = DropInRequest()
-                .threeDSecureRequest(ThreeDSecureRequest())
+        dropInRequest.threeDSecureRequest = ThreeDSecureRequest()
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val intent = Intent(context, DropInUnitTestActivity::class.java)
@@ -49,9 +49,8 @@ class DropInActivityUITest {
 
     @Test
     fun whenStateIsRESUMED_onCancelDropInEvent_finishesWithResult() {
-        val authorization = Authorization.fromString(Fixtures.TOKENIZATION_KEY)
         val dropInRequest = DropInRequest()
-                .threeDSecureRequest(ThreeDSecureRequest())
+        dropInRequest.threeDSecureRequest = ThreeDSecureRequest()
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val intent = Intent(context, DropInActivity::class.java)

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -70,7 +70,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsEnabledAndVaultedPaymentMethodsAreLoaded_displaysVaultedPaymentMethods() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = true
+        dropInRequest.isVaultManagerEnabled = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -97,7 +97,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerEnabledAndNoVaultedPaymentMethodsFound_showsNothing() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = true
+        dropInRequest.isVaultManagerEnabled = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -114,7 +114,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsEnabledAndVaultedPaymentMethodsAreLoaded_displaysVaultEditButton() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = true
+        dropInRequest.isVaultManagerEnabled = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -134,7 +134,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsDisabled_hidesVaultEditButton() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = false
+        dropInRequest.isVaultManagerEnabled = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -150,7 +150,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenCreditOrDebitCardSelected_sendsPaymentMethodSelectedEvent() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = false
+        dropInRequest.isVaultManagerEnabled = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -222,7 +222,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenPaymentMethodSelected_showsLoadingView() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = false
+        dropInRequest.isVaultManagerEnabled = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -242,7 +242,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenUserCanceledErrorPresentInViewModel_hidesLoader() {
         val dropInRequest = DropInRequest()
-        dropInRequest.enableVaultManager = false
+        dropInRequest.isVaultManagerEnabled = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -1,6 +1,5 @@
 package com.braintreepayments.api
 
-import android.os.Bundle
 import android.view.View.VISIBLE
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.FragmentScenario
@@ -71,7 +70,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsEnabledAndVaultedPaymentMethodsAreLoaded_displaysVaultedPaymentMethods() {
         val dropInRequest = DropInRequest()
-                .vaultManager(true)
+        dropInRequest.enableVaultManager = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -98,7 +97,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerEnabledAndNoVaultedPaymentMethodsFound_showsNothing() {
         val dropInRequest = DropInRequest()
-                .vaultManager(true)
+        dropInRequest.enableVaultManager = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -115,7 +114,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsEnabledAndVaultedPaymentMethodsAreLoaded_displaysVaultEditButton() {
         val dropInRequest = DropInRequest()
-                .vaultManager(true)
+        dropInRequest.enableVaultManager = true
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -135,7 +134,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenVaultManagerIsDisabled_hidesVaultEditButton() {
         val dropInRequest = DropInRequest()
-                .vaultManager(false)
+        dropInRequest.enableVaultManager = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -151,7 +150,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenCreditOrDebitCardSelected_sendsPaymentMethodSelectedEvent() {
         val dropInRequest = DropInRequest()
-                .vaultManager(false)
+        dropInRequest.enableVaultManager = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -223,7 +222,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenPaymentMethodSelected_showsLoadingView() {
         val dropInRequest = DropInRequest()
-                .vaultManager(false)
+        dropInRequest.enableVaultManager = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
@@ -243,7 +242,7 @@ class SupportedPaymentMethodsFragmentUITest {
     @Test
     fun whenStateIsRESUMED_whenUserCanceledErrorPresentInViewModel_hidesLoader() {
         val dropInRequest = DropInRequest()
-                .vaultManager(false)
+        dropInRequest.enableVaultManager = false
         val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
 
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)

--- a/Drop-In/src/main/java/com/braintreepayments/api/AvailablePaymentMethodNonceList.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AvailablePaymentMethodNonceList.java
@@ -20,7 +20,7 @@ class AvailablePaymentMethodNonceList {
             } else if (paymentMethodNonce instanceof CardNonce) {
                 shouldAddPaymentMethod = dropInRequest.isCardEnabled() && !configuration.getSupportedCardTypes().isEmpty();
             } else if (paymentMethodNonce instanceof GooglePayCardNonce) {
-                shouldAddPaymentMethod = googlePayEnabled && dropInRequest.isGooglePaymentEnabled();
+                shouldAddPaymentMethod = googlePayEnabled && dropInRequest.isGooglePayEnabled();
             }
 
             if (shouldAddPaymentMethod) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/AvailablePaymentMethodNonceList.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AvailablePaymentMethodNonceList.java
@@ -14,13 +14,13 @@ class AvailablePaymentMethodNonceList {
             boolean shouldAddPaymentMethod = false;
 
             if (paymentMethodNonce instanceof PayPalAccountNonce) {
-                shouldAddPaymentMethod = dropInRequest.isPayPalEnabled() && configuration.isPayPalEnabled();
+                shouldAddPaymentMethod = !dropInRequest.isPayPalDisabled() && configuration.isPayPalEnabled();
             } else if (paymentMethodNonce instanceof VenmoAccountNonce) {
-                shouldAddPaymentMethod = dropInRequest.isVenmoEnabled() && configuration.isVenmoEnabled();
+                shouldAddPaymentMethod = !dropInRequest.isVenmoDisabled() && configuration.isVenmoEnabled();
             } else if (paymentMethodNonce instanceof CardNonce) {
-                shouldAddPaymentMethod = dropInRequest.isCardEnabled() && !configuration.getSupportedCardTypes().isEmpty();
+                shouldAddPaymentMethod = !dropInRequest.isCardDisabled() && !configuration.getSupportedCardTypes().isEmpty();
             } else if (paymentMethodNonce instanceof GooglePayCardNonce) {
-                shouldAddPaymentMethod = googlePayEnabled && dropInRequest.isGooglePayEnabled();
+                shouldAddPaymentMethod = googlePayEnabled && !dropInRequest.isGooglePayDisabled();
             }
 
             if (shouldAddPaymentMethod) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/BaseActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/BaseActivity.java
@@ -57,7 +57,7 @@ class BaseActivity extends AppCompatActivity {
     }
 
     protected void finish(Exception e) {
-        setResult(RESULT_FIRST_USER, new Intent().putExtra(DropInActivity.EXTRA_ERROR, e));
+        setResult(RESULT_FIRST_USER, new Intent().putExtra(DropInResult.EXTRA_ERROR, e));
         finish();
     }
 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -100,7 +100,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
             }
         });
 
-        boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.isSaveCardCheckBoxShown();
+        boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.getAllowVaultCardOverride();
 
         cardForm.cardRequired(true)
                 .expirationRequired(true)
@@ -108,7 +108,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
                 .postalCodeRequired(configuration.isPostalCodeChallengePresent())
                 .cardholderName(dropInRequest.getCardholderNameStatus())
                 .saveCardCheckBoxVisible(showCardCheckbox)
-                .saveCardCheckBoxChecked(dropInRequest.getDefaultVaultSetting())
+                .saveCardCheckBoxChecked(dropInRequest.getVaultCardDefaultValue())
                 .setup(requireActivity());
 
         cardForm.maskCardNumber(dropInRequest.shouldMaskCardNumber());

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -111,8 +111,8 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
                 .saveCardCheckBoxChecked(dropInRequest.getVaultCardDefaultValue())
                 .setup(requireActivity());
 
-        cardForm.maskCardNumber(dropInRequest.shouldMaskCardNumber());
-        cardForm.maskCvv(dropInRequest.shouldMaskSecurityCode());
+        cardForm.maskCardNumber(dropInRequest.getShouldMaskCardNumber());
+        cardForm.maskCvv(dropInRequest.getShouldMaskSecurityCode());
         cardForm.setOnFormFieldFocusedListener(this);
 
         cardForm.getCardEditText().setText(cardNumber);

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -111,8 +111,8 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
                 .saveCardCheckBoxChecked(dropInRequest.getVaultCardDefaultValue())
                 .setup(requireActivity());
 
-        cardForm.maskCardNumber(dropInRequest.getShouldMaskCardNumber());
-        cardForm.maskCvv(dropInRequest.getShouldMaskSecurityCode());
+        cardForm.maskCardNumber(dropInRequest.getMaskCardNumber());
+        cardForm.maskCvv(dropInRequest.getMaskSecurityCode());
         cardForm.setOnFormFieldFocusedListener(this);
 
         cardForm.getCardEditText().setText(cardNumber);

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -29,6 +29,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
     private DropInRequest dropInRequest;
     private CardFormConfiguration configuration;
     private String cardNumber;
+    private Boolean isTokenizationKeyAuth;
 
     @VisibleForTesting
     DropInViewModel dropInViewModel;
@@ -45,6 +46,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
             dropInRequest = args.getParcelable("EXTRA_DROP_IN_REQUEST");
             configuration = args.getParcelable("EXTRA_CARD_FORM_CONFIGURATION");
             cardNumber = args.getString("EXTRA_CARD_NUMBER");
+            isTokenizationKeyAuth = args.getBoolean("EXTRA_AUTH_IS_TOKENIZATION_KEY");
         }
     }
 
@@ -98,8 +100,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
             }
         });
 
-        boolean showCardCheckbox = !Authorization.isTokenizationKey(dropInRequest.getAuthorization())
-                && dropInRequest.isSaveCardCheckBoxShown();
+        boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.isSaveCardCheckBoxShown();
 
         cardForm.cardRequired(true)
                 .expirationRequired(true)

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -168,7 +168,7 @@ public class CardDetailsFragment extends Fragment implements OnCardFormSubmitLis
         if (cardForm.isValid()) {
             animatedButtonView.showLoading();
 
-            boolean shouldVault = Authorization.fromString(dropInRequest.getAuthorization()) instanceof ClientToken && cardForm.isSaveCardCheckBoxChecked();
+            boolean shouldVault = !isTokenizationKeyAuth && cardForm.isSaveCardCheckBoxChecked();
 
             final Card card = new Card();
             card.setCardholderName(cardForm.getCardholderName());

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -312,6 +312,7 @@ public class DropInActivity extends BaseActivity {
                         args.putParcelable("EXTRA_DROP_IN_REQUEST", mDropInRequest);
                         args.putString("EXTRA_CARD_NUMBER", cardNumber);
                         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", cardFormConfiguration);
+                        args.putBoolean("EXTRA_AUTH_IS_TOKENIZATION_KEY", Authorization.isTokenizationKey(getDropInClient().getAuthorization().toString()));
 
                         replaceExistingFragment(CardDetailsFragment.class, CARD_DETAILS_TAG, args);
                     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -31,14 +31,6 @@ public class DropInActivity extends BaseActivity {
     private static final String CARD_DETAILS_TAG = "CARD_DETAILS";
     private static final String SELECT_PAYMENT_METHOD_TAG = "SELECT_PAYMENT_METHOD_PARENT_FRAGMENT";
 
-    /**
-     * Errors are returned as the serializable value of this key in the data intent in
-     * {@link #onActivityResult(int, int, android.content.Intent)} if
-     * responseCode is not {@link #RESULT_OK} or
-     * {@link #RESULT_CANCELED}.
-     */
-    public static final String EXTRA_ERROR = "com.braintreepayments.api.dropin.EXTRA_ERROR";
-
     @VisibleForTesting
     DropInViewModel dropInViewModel;
     ActionBar actionBar;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -3,12 +3,10 @@ package com.braintreepayments.api;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.View;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -452,7 +450,7 @@ public class DropInActivity extends BaseActivity {
                     final DropInResult dropInResult = new DropInResult();
                     dropInResult.paymentMethodNonce(paymentMethodNonce);
 
-                    if (mDropInRequest.shouldCollectDeviceData()) {
+                    if (mDropInRequest.getShouldCollectDeviceData()) {
                         getDropInClient().collectDeviceData(DropInActivity.this, new DataCollectorCallback() {
                             @Override
                             public void onResult(@Nullable String deviceData, @Nullable Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -450,7 +450,7 @@ public class DropInActivity extends BaseActivity {
                     final DropInResult dropInResult = new DropInResult();
                     dropInResult.paymentMethodNonce(paymentMethodNonce);
 
-                    if (mDropInRequest.getShouldCollectDeviceData()) {
+                    if (mDropInRequest.getCollectDeviceData()) {
                         getDropInClient().collectDeviceData(DropInActivity.this, new DataCollectorCallback() {
                             @Override
                             public void onResult(@Nullable String deviceData, @Nullable Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -9,11 +9,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
 
-import com.braintreepayments.cardform.utils.CardType;
-
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,7 +104,7 @@ public class DropInClient {
                             final DropInResult dropInResult = new DropInResult();
                             dropInResult.paymentMethodNonce(threeDSecureResult.getTokenizedCard());
 
-                            if (dropInRequest.shouldCollectDeviceData()) {
+                            if (dropInRequest.getShouldCollectDeviceData()) {
                                 dataCollector.collectDeviceData(activity, new DataCollectorCallback() {
                                     @Override
                                     public void onResult(@Nullable String deviceData, @Nullable Exception error) {
@@ -145,7 +141,7 @@ public class DropInClient {
                     boolean hasAmount = (dropInRequest.getThreeDSecureRequest() != null && !TextUtils.isEmpty(dropInRequest.getThreeDSecureRequest().getAmount()));
 
                     boolean shouldRequestThreeDSecureVerification =
-                            dropInRequest.shouldRequestThreeDSecureVerification()
+                            dropInRequest.getShouldRequestThreeDSecureVerification()
                                     && configuration.isThreeDSecureEnabled()
                                     && hasAmount;
                     callback.onResult(shouldRequestThreeDSecureVerification);
@@ -166,13 +162,13 @@ public class DropInClient {
     }
 
     void requestGooglePayPayment(FragmentActivity activity, GooglePayRequestPaymentCallback callback) {
-        googlePayClient.requestPayment(activity, dropInRequest.getGooglePaymentRequest(), callback);
+        googlePayClient.requestPayment(activity, dropInRequest.getGooglePayRequest(), callback);
     }
 
     void tokenizeVenmoAccount(FragmentActivity activity, VenmoTokenizeAccountCallback callback) {
         // TODO: Add VenmoRequest setter to DropInRequest and remove DropInRequest#shouldVaultVenmo()
         VenmoRequest venmoRequest = new VenmoRequest(VenmoPaymentMethodUsage.SINGLE_USE);
-        venmoRequest.setShouldVault(dropInRequest.shouldVaultVenmo());
+        venmoRequest.setShouldVault(dropInRequest.getVaultVenmoDefaultValue());
         venmoClient.tokenizeVenmoAccount(activity, venmoRequest, callback);
     }
 
@@ -279,7 +275,7 @@ public class DropInClient {
 
         final DropInResult dropInResult = new DropInResult()
                 .paymentMethodNonce(paymentMethodNonce);
-        if (dropInRequest.shouldCollectDeviceData()) {
+        if (dropInRequest.getShouldCollectDeviceData()) {
             dataCollector.collectDeviceData(activity, new DataCollectorCallback() {
                 @Override
                 public void onResult(@Nullable String deviceData, @Nullable Exception dataCollectionError) {
@@ -320,7 +316,7 @@ public class DropInClient {
                     return;
                 }
 
-                if (dropInRequest.isGooglePaymentEnabled()) {
+                if (dropInRequest.isGooglePayEnabled()) {
                     googlePayClient.isReadyToPay(activity, new GooglePayIsReadyToPayCallback() {
                         @Override
                         public void onResult(boolean isReadyToGooglePay, Exception error) {
@@ -362,7 +358,7 @@ public class DropInClient {
         }
 
         if (showGooglePay) {
-            if (dropInRequest.isGooglePaymentEnabled()) {
+            if (dropInRequest.isGooglePayEnabled()) {
                 availablePaymentMethods.add(DropInPaymentMethodType.GOOGLE_PAYMENT);
             }
         }
@@ -472,7 +468,7 @@ public class DropInClient {
                             return;
                         }
 
-                        if (dropInRequest.isGooglePaymentEnabled()) {
+                        if (dropInRequest.isGooglePayEnabled()) {
                             googlePayClient.isReadyToPay(activity, new GooglePayIsReadyToPayCallback() {
                                 @Override
                                 public void onResult(boolean isReadyToPay, Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -104,7 +104,7 @@ public class DropInClient {
                             final DropInResult dropInResult = new DropInResult();
                             dropInResult.paymentMethodNonce(threeDSecureResult.getTokenizedCard());
 
-                            if (dropInRequest.getShouldCollectDeviceData()) {
+                            if (dropInRequest.getCollectDeviceData()) {
                                 dataCollector.collectDeviceData(activity, new DataCollectorCallback() {
                                     @Override
                                     public void onResult(@Nullable String deviceData, @Nullable Exception error) {
@@ -141,7 +141,7 @@ public class DropInClient {
                     boolean hasAmount = (dropInRequest.getThreeDSecureRequest() != null && !TextUtils.isEmpty(dropInRequest.getThreeDSecureRequest().getAmount()));
 
                     boolean shouldRequestThreeDSecureVerification =
-                            dropInRequest.getShouldRequestThreeDSecureVerification()
+                            dropInRequest.getRequestThreeDSecureVerification()
                                     && configuration.isThreeDSecureEnabled()
                                     && hasAmount;
                     callback.onResult(shouldRequestThreeDSecureVerification);
@@ -275,7 +275,7 @@ public class DropInClient {
 
         final DropInResult dropInResult = new DropInResult()
                 .paymentMethodNonce(paymentMethodNonce);
-        if (dropInRequest.getShouldCollectDeviceData()) {
+        if (dropInRequest.getCollectDeviceData()) {
             dataCollector.collectDeviceData(activity, new DataCollectorCallback() {
                 @Override
                 public void onResult(@Nullable String deviceData, @Nullable Exception dataCollectionError) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -316,7 +316,7 @@ public class DropInClient {
                     return;
                 }
 
-                if (dropInRequest.isGooglePayEnabled()) {
+                if (!dropInRequest.isGooglePayDisabled()) {
                     googlePayClient.isReadyToPay(activity, new GooglePayIsReadyToPayCallback() {
                         @Override
                         public void onResult(boolean isReadyToGooglePay, Exception error) {
@@ -338,15 +338,15 @@ public class DropInClient {
     private List<DropInPaymentMethodType> filterSupportedPaymentMethods(Configuration configuration, boolean showGooglePay) {
         List<DropInPaymentMethodType> availablePaymentMethods = new ArrayList<>();
 
-        if (dropInRequest.isPayPalEnabled() && configuration.isPayPalEnabled()) {
+        if (!dropInRequest.isPayPalDisabled() && configuration.isPayPalEnabled()) {
             availablePaymentMethods.add(DropInPaymentMethodType.PAYPAL);
         }
 
-        if (dropInRequest.isVenmoEnabled() && configuration.isVenmoEnabled()) {
+        if (!dropInRequest.isVenmoDisabled() && configuration.isVenmoEnabled()) {
             availablePaymentMethods.add(DropInPaymentMethodType.PAY_WITH_VENMO);
         }
 
-        if (dropInRequest.isCardEnabled()) {
+        if (!dropInRequest.isCardDisabled()) {
             Set<String> supportedCardTypes =
                     new HashSet<>(configuration.getSupportedCardTypes());
             if (!configuration.isUnionPayEnabled()) {
@@ -358,7 +358,7 @@ public class DropInClient {
         }
 
         if (showGooglePay) {
-            if (dropInRequest.isGooglePayEnabled()) {
+            if (!dropInRequest.isGooglePayDisabled()) {
                 availablePaymentMethods.add(DropInPaymentMethodType.GOOGLE_PAYMENT);
             }
         }
@@ -468,7 +468,7 @@ public class DropInClient {
                             return;
                         }
 
-                        if (dropInRequest.isGooglePayEnabled()) {
+                        if (!dropInRequest.isGooglePayDisabled()) {
                             googlePayClient.isReadyToPay(activity, new GooglePayIsReadyToPayCallback() {
                                 @Override
                                 public void onResult(boolean isReadyToPay, Exception error) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -142,8 +142,7 @@ public class DropInClient {
                         return;
                     }
 
-                    boolean hasAmount = !TextUtils.isEmpty(dropInRequest.getAmount()) ||
-                            (dropInRequest.getThreeDSecureRequest() != null && !TextUtils.isEmpty(dropInRequest.getThreeDSecureRequest().getAmount()));
+                    boolean hasAmount = (dropInRequest.getThreeDSecureRequest() != null && !TextUtils.isEmpty(dropInRequest.getThreeDSecureRequest().getAmount()));
 
                     boolean shouldRequestThreeDSecureVerification =
                             dropInRequest.shouldRequestThreeDSecureVerification()

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -16,7 +16,6 @@ public class DropInRequest implements Parcelable {
 
     private String mAuthorization;
 
-    private String mAmount;
     private boolean mCollectDeviceData;
     private boolean mRequestThreeDSecureVerification;
     private ThreeDSecureRequest mThreeDSecureRequest;
@@ -38,22 +37,6 @@ public class DropInRequest implements Parcelable {
     private int mCardholderNameStatus = CardForm.FIELD_DISABLED;
 
     public DropInRequest() {}
-
-    /**
-     * Deprecated. Use {@link ThreeDSecureRequest#setAmount(String)}
-     *
-     * This method is optional. Amount is only used for 3D Secure verifications.
-     *
-     * This value must be a non-negative number and must match the currency format of the merchant account.
-     * It can only contain numbers and optionally one decimal point with exactly 2 decimal place precision (e.g., x.xx).
-     *
-     * @param amount Amount of the transaction.
-     */
-    @Deprecated
-    public DropInRequest amount(String amount) {
-        mAmount = amount;
-        return this;
-    }
 
     /**
      * This method is optional.
@@ -123,8 +106,8 @@ public class DropInRequest implements Parcelable {
 
     /**
      * If 3D Secure has been enabled in the control panel and an amount is specified in
-     * {@link DropInRequest#amount(String)} or a {@link ThreeDSecureRequest} is provided,
-     * Drop-In will request a 3D Secure verification for any new cards added by the user.
+     * a {@link ThreeDSecureRequest} that is provided, Drop-In will request a 3D Secure verification
+     * for any new cards added by the user.
      *
      * @param requestThreeDSecure {@code true} to request a 3D Secure verification as part of Drop-In,
      * {@code false} to not request a 3D Secure verification. Defaults to {@code false}.
@@ -235,10 +218,6 @@ public class DropInRequest implements Parcelable {
         return mAuthorization;
     }
 
-    String getAmount() {
-        return mAmount;
-    }
-
     boolean shouldCollectDeviceData() {
         return mCollectDeviceData;
     }
@@ -306,7 +285,6 @@ public class DropInRequest implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(mAuthorization);
-        dest.writeString(mAmount);
         dest.writeByte(mCollectDeviceData ? (byte) 1 : (byte) 0);
         dest.writeParcelable(mGooglePaymentRequest, 0);
         dest.writeByte(mGooglePaymentEnabled ? (byte) 1 : (byte) 0);
@@ -327,7 +305,6 @@ public class DropInRequest implements Parcelable {
 
     protected DropInRequest(Parcel in) {
         mAuthorization = in.readString();
-        mAmount = in.readString();
         mCollectDeviceData = in.readByte() != 0;
         mGooglePaymentRequest = in.readParcelable(GooglePayRequest.class.getClassLoader());
         mGooglePaymentEnabled = in.readByte() != 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -24,11 +24,11 @@ public class DropInRequest implements Parcelable {
     private boolean payPalDisabled = false;
     private boolean venmoDisabled = false;
     private boolean cardDisabled = false;
-    private boolean mDefaultVaultValue = true;
-    private boolean mShowCheckBoxToAllowVaultOverride = false;
-    private boolean mVaultVenmo = false;
+    private boolean vaultCardDefaultValue = true;
+    private boolean allowVaultCardOverride = false;
+    private boolean vaultVenmoDefaultValue = false;
 
-    private int mCardholderNameStatus = CardForm.FIELD_DISABLED;
+    private int cardholderNameStatus = CardForm.FIELD_DISABLED;
 
     public DropInRequest() {}
 
@@ -166,27 +166,33 @@ public class DropInRequest implements Parcelable {
      * This value is {@code true} by default.
      */
     public void setVaultCardDefaultValue(boolean defaultValue) {
-        mDefaultVaultValue = defaultValue;
+        vaultCardDefaultValue = defaultValue;
     }
 
     /**
-     * @param defaultValue the default value used to determine if Drop-in should vault the customer's venmo payment method. Must be set to `false` when using a client token without a `customerId`.
+     * This method is optional.
+     *
+     * @param defaultValue the default value used to determine if Drop-in should vault the customer's Venmo payment method. Must be set to `false` when using a client token without a `customerId`.
      *
      * This value is {@code false} by default.
      */
     public void setVaultVenmoDefaultValue(boolean defaultValue) {
-        mVaultVenmo = defaultValue;
+        vaultVenmoDefaultValue = defaultValue;
     }
 
     /**
+     * This method is optional.
+     *
      * @param customerCheckBoxEnabled {@code true} shows save card CheckBox to allow user to choose whether or not to vault their card.
-     * {@code false} does not show Save Card CheckBox.
+     * {@code false} does not show Save Card CheckBox. Default value is false.
      */
     public void setAllowVaultCardOverride(boolean customerCheckBoxEnabled) {
-        mShowCheckBoxToAllowVaultOverride = customerCheckBoxEnabled;
+        allowVaultCardOverride = customerCheckBoxEnabled;
     }
 
     /**
+     * This method is optional.
+     *
      * Sets the Cardholder Name field status, which is how it will behave in {@link CardForm}.
      * Default is {@link CardForm#FIELD_DISABLED}.
      *
@@ -194,65 +200,113 @@ public class DropInRequest implements Parcelable {
      * {@link CardForm#FIELD_REQUIRED}.
      */
     public void setCardholderNameStatus(int fieldStatus) {
-        mCardholderNameStatus = fieldStatus;
+        cardholderNameStatus = fieldStatus;
     }
 
-    boolean getShouldCollectDeviceData() {
+    /**
+     * @return If Drop-in should collect and return device data for fraud prevention.
+     */
+    public boolean getShouldCollectDeviceData() {
         return shouldCollectDeviceData;
     }
 
+    /**
+     * @return If PayPal is disabled in Drop-in
+     */
     public boolean getPayPalDisabled() {
         return payPalDisabled;
     }
 
+    /**
+     * @return The PayPal Request {@link PayPalRequest} for the transaction.
+     */
     public PayPalRequest getPayPalRequest() { return payPalRequest; }
 
+    /**
+     * @return If Venmo is disabled in Drop-in
+     */
     public boolean getVenmoDisabled() {
         return venmoDisabled;
     }
 
+    /**
+     * @return If card payments are disabled in Drop-in
+     */
     public boolean getCardDisabled() {
         return cardDisabled;
     }
 
+    /**
+     * @return The Google Pay Request {@link GooglePayRequest} for the transaction.
+     */
     public GooglePayRequest getGooglePayRequest() {
         return googlePayRequest;
     }
 
+    /**
+     * @return If Google Pay disabled in Drop-in
+     */
     public boolean getGooglePayDisabled() {
         return googlePayDisabled;
     }
 
-    boolean getShouldRequestThreeDSecureVerification() {
+    /**
+     * @return If a 3D Secure verification should be requested as part of Drop-in
+     */
+    public boolean getShouldRequestThreeDSecureVerification() {
         return requestThreeDSecureVerification;
     }
 
+    /**
+     * @return The {@link ThreeDSecureRequest} for the transaction.
+     */
     public ThreeDSecureRequest getThreeDSecureRequest() { return threeDSecureRequest; }
 
-    boolean getShouldMaskCardNumber() {
+    /**
+     * @return If the card number field should be masked when the field is not focused.
+     */
+    public boolean getShouldMaskCardNumber() {
         return shouldMaskCardNumber;
     }
 
-    boolean getShouldMaskSecurityCode() {
+    /**
+     * @return If the security code should be masked during input.
+     */
+    public boolean getShouldMaskSecurityCode() {
         return shouldMaskSecurityCode;
     }
 
-    boolean getVaultVenmoDefaultValue() { return mVaultVenmo; }
+    /**
+     * @return The default value used to determine if Drop-in should vault the customer's Venmo payment method
+     */
+    public boolean getVaultVenmoDefaultValue() { return vaultVenmoDefaultValue; }
 
-    boolean getEnableVaultManager() {
+    /**
+     * @return If vault manager is enabled to allow users manage their vaulted payment methods
+     */
+    public boolean getEnableVaultManager() {
         return enableVaultManager;
     }
 
+    /**
+     * @return The Cardholder Name field status, which is how it will behave in {@link CardForm}.
+     */
     public int getCardholderNameStatus() {
-        return mCardholderNameStatus;
+        return cardholderNameStatus;
     }
 
+    /**
+     * @return The default value used to determine if Drop-in should vault the customer's card.
+     */
     public boolean getVaultCardDefaultValue() {
-        return mDefaultVaultValue;
+        return vaultCardDefaultValue;
     }
 
+    /**
+     * @return If the save card CheckBox will be shown to allow user to choose whether or not to vault their card.
+     */
     public boolean getAllowVaultCardOverride() {
-        return mShowCheckBoxToAllowVaultOverride;
+        return allowVaultCardOverride;
     }
 
     boolean isPayPalEnabled() {
@@ -290,10 +344,10 @@ public class DropInRequest implements Parcelable {
         dest.writeByte(shouldMaskCardNumber ? (byte) 1 : (byte) 0);
         dest.writeByte(shouldMaskSecurityCode ? (byte) 1 : (byte) 0);
         dest.writeByte(enableVaultManager ? (byte) 1 : (byte) 0);
-        dest.writeInt(mCardholderNameStatus);
-        dest.writeByte(mDefaultVaultValue ? (byte) 1 : (byte) 0);
-        dest.writeByte(mShowCheckBoxToAllowVaultOverride ? (byte) 1 : (byte) 0);
-        dest.writeByte(mVaultVenmo ? (byte) 1 : (byte) 0);
+        dest.writeInt(cardholderNameStatus);
+        dest.writeByte(vaultCardDefaultValue ? (byte) 1 : (byte) 0);
+        dest.writeByte(allowVaultCardOverride ? (byte) 1 : (byte) 0);
+        dest.writeByte(vaultVenmoDefaultValue ? (byte) 1 : (byte) 0);
     }
 
     protected DropInRequest(Parcel in) {
@@ -309,10 +363,10 @@ public class DropInRequest implements Parcelable {
         shouldMaskCardNumber = in.readByte() != 0;
         shouldMaskSecurityCode = in.readByte() != 0;
         enableVaultManager = in.readByte() != 0;
-        mCardholderNameStatus = in.readInt();
-        mDefaultVaultValue = in.readByte() != 0;
-        mShowCheckBoxToAllowVaultOverride = in.readByte() != 0;
-        mVaultVenmo = in.readByte() != 0;
+        cardholderNameStatus = in.readInt();
+        vaultCardDefaultValue = in.readByte() != 0;
+        allowVaultCardOverride = in.readByte() != 0;
+        vaultVenmoDefaultValue = in.readByte() != 0;
     }
 
     public static final Creator<DropInRequest> CREATOR = new Creator<DropInRequest>() {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -1,7 +1,5 @@
 package com.braintreepayments.api;
 
-import android.content.Context;
-import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -12,24 +10,20 @@ import com.braintreepayments.cardform.view.CardForm;
  */
 public class DropInRequest implements Parcelable {
 
-    public static final String EXTRA_CHECKOUT_REQUEST = "com.braintreepayments.api.EXTRA_CHECKOUT_REQUEST";
+    private boolean shouldCollectDeviceData;
+    private boolean requestThreeDSecureVerification;
+    private ThreeDSecureRequest threeDSecureRequest;
 
-    private String mAuthorization;
+    private GooglePayRequest googlePayRequest;
+    private PayPalRequest payPalRequest;
 
-    private boolean mCollectDeviceData;
-    private boolean mRequestThreeDSecureVerification;
-    private ThreeDSecureRequest mThreeDSecureRequest;
-
-    private GooglePayRequest mGooglePaymentRequest;
-    private PayPalRequest mPayPalRequest;
-
-    private boolean mGooglePaymentDisabled = false;
-    private boolean mMaskCardNumber = false;
-    private boolean mMaskSecurityCode = false;
-    private boolean mVaultManagerEnabled = false;
-    private boolean mPayPalDisabled = false;
-    private boolean mVenmoDisabled = false;
-    private boolean mCardDisabled = false;
+    private boolean googlePayDisabled = false;
+    private boolean shouldMaskCardNumber = false;
+    private boolean shouldMaskSecurityCode = false;
+    private boolean enableVaultManager = false;
+    private boolean payPalDisabled = false;
+    private boolean venmoDisabled = false;
+    private boolean cardDisabled = false;
     private boolean mDefaultVaultValue = true;
     private boolean mShowCheckBoxToAllowVaultOverride = false;
     private boolean mVaultVenmo = false;
@@ -46,7 +40,7 @@ public class DropInRequest implements Parcelable {
      * @see DataCollector
      */
     public void setShouldCollectDeviceData(boolean collectDeviceData) {
-        mCollectDeviceData = collectDeviceData;
+        shouldCollectDeviceData = collectDeviceData;
     }
 
     /**
@@ -55,7 +49,7 @@ public class DropInRequest implements Parcelable {
      * @param request The Google Pay Request {@link GooglePayRequest} for the transaction.
      */
     public void setGooglePayRequest(GooglePayRequest request) {
-        mGooglePaymentRequest = request;
+        googlePayRequest = request;
     }
 
     /**
@@ -66,42 +60,48 @@ public class DropInRequest implements Parcelable {
      * If amount is set, PayPal will follow the one time payment (Checkout) flow.
      */
     public void setPayPalRequest(PayPalRequest request) {
-        mPayPalRequest = request;
+        payPalRequest = request;
     }
 
     /**
-     * Disables Google Pay in Drop-in.
-     * @param disableGooglePay
+     * This method is optional.
+     *
+     * @param disableGooglePay If set to true, disables Google Pay in Drop-in. Default value is false.
      */
     public void setGooglePayDisabled(boolean disableGooglePay) {
-        mGooglePaymentDisabled = disableGooglePay;
+        googlePayDisabled = disableGooglePay;
     }
 
     /**
-     * Disables PayPal in Drop-in.
-     * @param disablePayPal
+     * This method is optional.
+     *
+     * @param disablePayPal If set to true, disables PayPal in Drop-in. Default value is false.
      */
     public void setPayPalDisabled(boolean disablePayPal) {
-        mPayPalDisabled = disablePayPal;
+        payPalDisabled = disablePayPal;
     }
 
     /**
-     * Disables Venmo in Drop-in.
-     * @param disableVenmo
+     * This method is optional.
+     *
+     * @param disableVenmo If set to true, disables Venmo in Drop-in. Default value is false.
      */
     public void setVenmoDisabled(boolean disableVenmo) {
-        mVenmoDisabled = disableVenmo;
+        venmoDisabled = disableVenmo;
     }
 
     /**
-     * Disables Card in Drop-in.
-     * @param disableCard
+     * This method is optional.
+     *
+     * @param disableCard If set to true, disables Card in Drop-in. Default value is false.
      */
     public void setCardDisabled(boolean disableCard) {
-        mCardDisabled = disableCard;
+        cardDisabled = disableCard;
     }
 
     /**
+     * This method is optional.
+     *
      * If 3D Secure has been enabled in the control panel and an amount is specified in
      * a {@link ThreeDSecureRequest} that is provided, Drop-In will request a 3D Secure verification
      * for any new cards added by the user.
@@ -110,7 +110,7 @@ public class DropInRequest implements Parcelable {
      * {@code false} to not request a 3D Secure verification. Defaults to {@code false}.
      */
     public void setShouldRequestThreeDSecureVerification(boolean requestThreeDSecure) {
-        mRequestThreeDSecureVerification = requestThreeDSecure;
+        requestThreeDSecureVerification = requestThreeDSecure;
     }
 
     /**
@@ -121,34 +121,42 @@ public class DropInRequest implements Parcelable {
      * {@link ThreeDSecureRequest#setEmail(String)}, and {@link ThreeDSecureRequest#setMobilePhoneNumber(String)} for best results.
      */
     public void setThreeDSecureRequest(ThreeDSecureRequest threeDSecureRequest) {
-        mThreeDSecureRequest = threeDSecureRequest;
+        this.threeDSecureRequest = threeDSecureRequest;
     }
 
     /**
+     * This method is optional.
+     *
      * @param maskCardNumber {@code true} to mask the card number when the field is not focused.
      * See {@link com.braintreepayments.cardform.view.CardEditText} for more details. Defaults to
      * {@code false}.
      */
     public void setShouldMaskCardNumber(boolean maskCardNumber) {
-        mMaskCardNumber = maskCardNumber;
+        shouldMaskCardNumber = maskCardNumber;
     }
 
     /**
+     * This method is optional.
+     *
      * @param maskSecurityCode {@code true} to mask the security code during input. Defaults to {@code false}.
      */
     public void setShouldMaskSecurityCode(boolean maskSecurityCode) {
-        mMaskSecurityCode = maskSecurityCode;
+        shouldMaskSecurityCode = maskSecurityCode;
     }
 
     /**
+     * This method is optional.
+     *
      * @param vaultManager {@code true} to allow customers to manage their vaulted payment methods.
      * Defaults to {@code false}.
      */
     public void setEnableVaultManager(boolean vaultManager) {
-        mVaultManagerEnabled = vaultManager;
+        enableVaultManager = vaultManager;
     }
 
     /**
+     * This method is optional.
+     *
      * @param defaultValue the default value used to determine if Drop-in should vault the customer's card. This setting can be overwritten by the customer if the save card checkbox is visible using {@link #setAllowVaultCardOverride(boolean)}
      * If the save card CheckBox is shown, and default vault value is true: the save card CheckBox will appear pre-checked.
      * If the save card CheckBox is shown, and default vault value is false: the save card Checkbox will appear un-checked.
@@ -168,7 +176,7 @@ public class DropInRequest implements Parcelable {
      */
     public void setVaultVenmoDefaultValue(boolean defaultValue) {
         mVaultVenmo = defaultValue;
-    };
+    }
 
     /**
      * @param customerCheckBoxEnabled {@code true} shows save card CheckBox to allow user to choose whether or not to vault their card.
@@ -189,54 +197,50 @@ public class DropInRequest implements Parcelable {
         mCardholderNameStatus = fieldStatus;
     }
 
-    public String getAuthorization() {
-        return mAuthorization;
-    }
-
     boolean getShouldCollectDeviceData() {
-        return mCollectDeviceData;
+        return shouldCollectDeviceData;
     }
 
     public boolean getPayPalDisabled() {
-        return mPayPalDisabled;
+        return payPalDisabled;
     }
 
-    public PayPalRequest getPayPalRequest() { return mPayPalRequest; }
+    public PayPalRequest getPayPalRequest() { return payPalRequest; }
 
     public boolean getVenmoDisabled() {
-        return mVenmoDisabled;
+        return venmoDisabled;
     }
 
     public boolean getCardDisabled() {
-        return mCardDisabled;
+        return cardDisabled;
     }
 
     public GooglePayRequest getGooglePayRequest() {
-        return mGooglePaymentRequest;
+        return googlePayRequest;
     }
 
     public boolean getGooglePayDisabled() {
-        return mGooglePaymentDisabled;
+        return googlePayDisabled;
     }
 
     boolean getShouldRequestThreeDSecureVerification() {
-        return mRequestThreeDSecureVerification;
+        return requestThreeDSecureVerification;
     }
 
-    public ThreeDSecureRequest getThreeDSecureRequest() { return mThreeDSecureRequest; }
+    public ThreeDSecureRequest getThreeDSecureRequest() { return threeDSecureRequest; }
 
     boolean getShouldMaskCardNumber() {
-        return mMaskCardNumber;
+        return shouldMaskCardNumber;
     }
 
     boolean getShouldMaskSecurityCode() {
-        return mMaskSecurityCode;
+        return shouldMaskSecurityCode;
     }
 
     boolean getVaultVenmoDefaultValue() { return mVaultVenmo; }
 
     boolean getEnableVaultManager() {
-        return mVaultManagerEnabled;
+        return enableVaultManager;
     }
 
     public int getCardholderNameStatus() {
@@ -252,19 +256,19 @@ public class DropInRequest implements Parcelable {
     }
 
     boolean isPayPalEnabled() {
-        return !mPayPalDisabled;
+        return !payPalDisabled;
     }
 
     boolean isVenmoEnabled() {
-        return !mVenmoDisabled;
+        return !venmoDisabled;
     }
 
     boolean isGooglePayEnabled() {
-        return !mGooglePaymentDisabled;
+        return !googlePayDisabled;
     }
 
     boolean isCardEnabled() {
-        return !mCardDisabled;
+        return !cardDisabled;
     }
 
     @Override
@@ -274,19 +278,18 @@ public class DropInRequest implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(mAuthorization);
-        dest.writeByte(mCollectDeviceData ? (byte) 1 : (byte) 0);
-        dest.writeParcelable(mGooglePaymentRequest, 0);
-        dest.writeByte(mGooglePaymentDisabled ? (byte) 1 : (byte) 0);
-        dest.writeParcelable(mPayPalRequest, 0);
-        dest.writeByte(mPayPalDisabled ? (byte) 1 : (byte) 0);
-        dest.writeByte(mVenmoDisabled ? (byte) 1 : (byte) 0);
-        dest.writeByte(mCardDisabled ? (byte) 1 : (byte) 0);
-        dest.writeByte(mRequestThreeDSecureVerification ? (byte) 1 : (byte) 0);
-        dest.writeParcelable(mThreeDSecureRequest, 0);
-        dest.writeByte(mMaskCardNumber ? (byte) 1 : (byte) 0);
-        dest.writeByte(mMaskSecurityCode ? (byte) 1 : (byte) 0);
-        dest.writeByte(mVaultManagerEnabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(shouldCollectDeviceData ? (byte) 1 : (byte) 0);
+        dest.writeParcelable(googlePayRequest, 0);
+        dest.writeByte(googlePayDisabled ? (byte) 1 : (byte) 0);
+        dest.writeParcelable(payPalRequest, 0);
+        dest.writeByte(payPalDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(venmoDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(cardDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(requestThreeDSecureVerification ? (byte) 1 : (byte) 0);
+        dest.writeParcelable(threeDSecureRequest, 0);
+        dest.writeByte(shouldMaskCardNumber ? (byte) 1 : (byte) 0);
+        dest.writeByte(shouldMaskSecurityCode ? (byte) 1 : (byte) 0);
+        dest.writeByte(enableVaultManager ? (byte) 1 : (byte) 0);
         dest.writeInt(mCardholderNameStatus);
         dest.writeByte(mDefaultVaultValue ? (byte) 1 : (byte) 0);
         dest.writeByte(mShowCheckBoxToAllowVaultOverride ? (byte) 1 : (byte) 0);
@@ -294,19 +297,18 @@ public class DropInRequest implements Parcelable {
     }
 
     protected DropInRequest(Parcel in) {
-        mAuthorization = in.readString();
-        mCollectDeviceData = in.readByte() != 0;
-        mGooglePaymentRequest = in.readParcelable(GooglePayRequest.class.getClassLoader());
-        mGooglePaymentDisabled = in.readByte() != 0;
-        mPayPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
-        mPayPalDisabled = in.readByte() != 0;
-        mVenmoDisabled = in.readByte() != 0;
-        mCardDisabled = in.readByte() != 0;
-        mRequestThreeDSecureVerification = in.readByte() != 0;
-        mThreeDSecureRequest = in.readParcelable(ThreeDSecureRequest.class.getClassLoader());
-        mMaskCardNumber = in.readByte() != 0;
-        mMaskSecurityCode = in.readByte() != 0;
-        mVaultManagerEnabled = in.readByte() != 0;
+        shouldCollectDeviceData = in.readByte() != 0;
+        googlePayRequest = in.readParcelable(GooglePayRequest.class.getClassLoader());
+        googlePayDisabled = in.readByte() != 0;
+        payPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
+        payPalDisabled = in.readByte() != 0;
+        venmoDisabled = in.readByte() != 0;
+        cardDisabled = in.readByte() != 0;
+        requestThreeDSecureVerification = in.readByte() != 0;
+        threeDSecureRequest = in.readParcelable(ThreeDSecureRequest.class.getClassLoader());
+        shouldMaskCardNumber = in.readByte() != 0;
+        shouldMaskSecurityCode = in.readByte() != 0;
+        enableVaultManager = in.readByte() != 0;
         mCardholderNameStatus = in.readInt();
         mDefaultVaultValue = in.readByte() != 0;
         mShowCheckBoxToAllowVaultOverride = in.readByte() != 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -309,22 +309,6 @@ public class DropInRequest implements Parcelable {
         return allowVaultCardOverride;
     }
 
-    boolean isPayPalEnabled() {
-        return !payPalDisabled;
-    }
-
-    boolean isVenmoEnabled() {
-        return !venmoDisabled;
-    }
-
-    boolean isGooglePayEnabled() {
-        return !googlePayDisabled;
-    }
-
-    boolean isCardEnabled() {
-        return !cardDisabled;
-    }
-
     @Override
     public int describeContents() {
         return 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -189,18 +189,6 @@ public class DropInRequest implements Parcelable {
         mCardholderNameStatus = fieldStatus;
     }
 
-    /**
-     * Get an {@link Intent} that can be used in {@link androidx.appcompat.app.AppCompatActivity#startActivityForResult(Intent, int)}
-     * to launch {@link DropInActivity} and the Drop-in UI.
-     *
-     * @param context
-     * @return {@link Intent} containing all of the options set in {@link DropInRequest}.
-     */
-    public Intent getIntent(Context context) {
-        return new Intent(context, DropInActivity.class)
-                .putExtra(EXTRA_CHECKOUT_REQUEST, this);
-    }
-
     public String getAuthorization() {
         return mAuthorization;
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -45,19 +45,17 @@ public class DropInRequest implements Parcelable {
      *        fraud prevention.
      * @see DataCollector
      */
-    public DropInRequest collectDeviceData(boolean collectDeviceData) {
+    public void setShouldCollectDeviceData(boolean collectDeviceData) {
         mCollectDeviceData = collectDeviceData;
-        return this;
     }
 
     /**
      * This method is optional.
      *
-     * @param request The Google Payment Request {@link GooglePayRequest} for the transaction.
+     * @param request The Google Pay Request {@link GooglePayRequest} for the transaction.
      */
-    public DropInRequest googlePaymentRequest(GooglePayRequest request) {
+    public void setGooglePayRequest(GooglePayRequest request) {
         mGooglePaymentRequest = request;
-        return this;
     }
 
     /**
@@ -67,41 +65,40 @@ public class DropInRequest implements Parcelable {
      * If no amount is set, PayPal will default to the billing agreement (Vault) flow.
      * If amount is set, PayPal will follow the one time payment (Checkout) flow.
      */
-    public DropInRequest paypalRequest(PayPalRequest request) {
+    public void setPayPalRequest(PayPalRequest request) {
         mPayPalRequest = request;
-        return this;
     }
 
     /**
-     * Disables Google Payment in Drop-in.
+     * Disables Google Pay in Drop-in.
+     * @param disableGooglePay
      */
-    public DropInRequest disableGooglePayment() {
-        mGooglePaymentEnabled = false;
-        return this;
+    public void setDisableGooglePay(boolean disableGooglePay) {
+        mGooglePaymentEnabled = !disableGooglePay;
     }
 
     /**
      * Disables PayPal in Drop-in.
+     * @param disablePayPal
      */
-    public DropInRequest disablePayPal() {
-        mPayPalEnabled = false;
-        return this;
+    public void setDisablePayPal(boolean disablePayPal) {
+        mPayPalEnabled = !disablePayPal;
     }
 
     /**
      * Disables Venmo in Drop-in.
+     * @param disableVenmo
      */
-    public DropInRequest disableVenmo() {
-        mVenmoEnabled = false;
-        return this;
+    public void setDisableVenmo(boolean disableVenmo) {
+        mVenmoEnabled = !disableVenmo;
     }
 
     /**
      * Disables Card in Drop-in.
+     * @param disableCard
      */
-    public DropInRequest disableCard() {
-        mCardEnabled = false;
-        return this;
+    public void setDisableCard(boolean disableCard) {
+        mCardEnabled = !disableCard;
     }
 
     /**
@@ -112,9 +109,8 @@ public class DropInRequest implements Parcelable {
      * @param requestThreeDSecure {@code true} to request a 3D Secure verification as part of Drop-In,
      * {@code false} to not request a 3D Secure verification. Defaults to {@code false}.
      */
-    public DropInRequest requestThreeDSecureVerification(boolean requestThreeDSecure) {
+    public void setShouldRequestThreeDSecureVerification(boolean requestThreeDSecure) {
         mRequestThreeDSecureVerification = requestThreeDSecure;
-        return this;
     }
 
     /**
@@ -123,11 +119,9 @@ public class DropInRequest implements Parcelable {
      * @param threeDSecureRequest {@link ThreeDSecureRequest} to specify options and additional information for 3D Secure.
      * To encourage 3DS 2.0 flows, set {@link ThreeDSecureRequest#setBillingAddress(ThreeDSecurePostalAddress)},
      * {@link ThreeDSecureRequest#setEmail(String)}, and {@link ThreeDSecureRequest#setMobilePhoneNumber(String)} for best results.
-     * If no amount is set, the {@link DropInRequest#amount(String)} will be used.
      */
-    public DropInRequest threeDSecureRequest(ThreeDSecureRequest threeDSecureRequest) {
+    public void setThreeDSecureRequest(ThreeDSecureRequest threeDSecureRequest) {
         mThreeDSecureRequest = threeDSecureRequest;
-        return this;
     }
 
     /**
@@ -135,30 +129,27 @@ public class DropInRequest implements Parcelable {
      * See {@link com.braintreepayments.cardform.view.CardEditText} for more details. Defaults to
      * {@code false}.
      */
-    public DropInRequest maskCardNumber(boolean maskCardNumber) {
+    public void setMaskCardNumber(boolean maskCardNumber) {
         mMaskCardNumber = maskCardNumber;
-        return this;
     }
 
     /**
      * @param maskSecurityCode {@code true} to mask the security code during input. Defaults to {@code false}.
      */
-    public DropInRequest maskSecurityCode(boolean maskSecurityCode) {
+    public void setMaskSecurityCode(boolean maskSecurityCode) {
         mMaskSecurityCode = maskSecurityCode;
-        return this;
     }
 
     /**
      * @param vaultManager {@code true} to allow customers to manage their vaulted payment methods.
      * Defaults to {@code false}.
      */
-    public DropInRequest vaultManager(boolean vaultManager) {
+    public void setEnableVaultManager(boolean vaultManager) {
         mVaultManagerEnabled = vaultManager;
-        return this;
     }
 
     /**
-     * @param defaultValue the default value used to determine if Drop-in should vault the customer's card. This setting can be overwritten by the customer if the save card checkbox is visible using {@link #allowVaultCardOverride(boolean)}
+     * @param defaultValue the default value used to determine if Drop-in should vault the customer's card. This setting can be overwritten by the customer if the save card checkbox is visible using {@link #setAllowVaultCardOverride(boolean)}
      * If the save card CheckBox is shown, and default vault value is true: the save card CheckBox will appear pre-checked.
      * If the save card CheckBox is shown, and default vault value is false: the save card Checkbox will appear un-checked.
      * If the save card CheckBox is not shown, and default vault value is true: card always vaults.
@@ -166,9 +157,8 @@ public class DropInRequest implements Parcelable {
      *
      * This value is {@code true} by default.
      */
-    public DropInRequest vaultCard(boolean defaultValue) {
+    public void setVaultCardDefaultValue(boolean defaultValue) {
         mDefaultVaultValue = defaultValue;
-        return this;
     }
 
     /**
@@ -176,18 +166,16 @@ public class DropInRequest implements Parcelable {
      *
      * This value is {@code false} by default.
      */
-    public DropInRequest vaultVenmo(boolean defaultValue) {
+    public void setVaultVenmoDefaultValue(boolean defaultValue) {
         mVaultVenmo = defaultValue;
-        return this;
     };
 
     /**
      * @param customerCheckBoxEnabled {@code true} shows save card CheckBox to allow user to choose whether or not to vault their card.
      * {@code false} does not show Save Card CheckBox.
      */
-    public DropInRequest allowVaultCardOverride(boolean customerCheckBoxEnabled) {
+    public void setAllowVaultCardOverride(boolean customerCheckBoxEnabled) {
         mShowCheckBoxToAllowVaultOverride = customerCheckBoxEnabled;
-        return this;
     }
 
     /**
@@ -197,9 +185,8 @@ public class DropInRequest implements Parcelable {
      * Can be {@link CardForm#FIELD_DISABLED}, {@link CardForm#FIELD_OPTIONAL}, or
      * {@link CardForm#FIELD_REQUIRED}.
      */
-    public DropInRequest cardholderNameStatus(int fieldStatus) {
+    public void setCardholderNameStatus(int fieldStatus) {
         mCardholderNameStatus = fieldStatus;
-        return this;
     }
 
     /**
@@ -261,7 +248,7 @@ public class DropInRequest implements Parcelable {
 
     boolean shouldVaultVenmo() { return mVaultVenmo; }
 
-    boolean isVaultManagerEnabled() {
+    boolean getEnableVaultManager() {
         return mVaultManagerEnabled;
     }
 
@@ -269,11 +256,11 @@ public class DropInRequest implements Parcelable {
         return mCardholderNameStatus;
     }
 
-    public boolean getDefaultVaultSetting() {
+    public boolean getVaultCardDefaultValue() {
         return mDefaultVaultValue;
     }
 
-    public boolean isSaveCardCheckBoxShown() {
+    public boolean getAllowVaultCardOverride() {
         return mShowCheckBoxToAllowVaultOverride;
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -10,7 +10,7 @@ import com.braintreepayments.cardform.view.CardForm;
  */
 public class DropInRequest implements Parcelable {
 
-    private boolean shouldCollectDeviceData;
+    private boolean collectDeviceData;
     private boolean requestThreeDSecureVerification;
     private ThreeDSecureRequest threeDSecureRequest;
 
@@ -18,9 +18,9 @@ public class DropInRequest implements Parcelable {
     private PayPalRequest payPalRequest;
 
     private boolean googlePayDisabled = false;
-    private boolean shouldMaskCardNumber = false;
-    private boolean shouldMaskSecurityCode = false;
-    private boolean enableVaultManager = false;
+    private boolean maskCardNumber = false;
+    private boolean maskSecurityCode = false;
+    private boolean vaultManagerEnabled = false;
     private boolean payPalDisabled = false;
     private boolean venmoDisabled = false;
     private boolean cardDisabled = false;
@@ -39,8 +39,8 @@ public class DropInRequest implements Parcelable {
      *        fraud prevention.
      * @see DataCollector
      */
-    public void setShouldCollectDeviceData(boolean collectDeviceData) {
-        shouldCollectDeviceData = collectDeviceData;
+    public void setCollectDeviceData(boolean collectDeviceData) {
+        this.collectDeviceData = collectDeviceData;
     }
 
     /**
@@ -109,7 +109,7 @@ public class DropInRequest implements Parcelable {
      * @param requestThreeDSecure {@code true} to request a 3D Secure verification as part of Drop-In,
      * {@code false} to not request a 3D Secure verification. Defaults to {@code false}.
      */
-    public void setShouldRequestThreeDSecureVerification(boolean requestThreeDSecure) {
+    public void setRequestThreeDSecureVerification(boolean requestThreeDSecure) {
         requestThreeDSecureVerification = requestThreeDSecure;
     }
 
@@ -131,8 +131,8 @@ public class DropInRequest implements Parcelable {
      * See {@link com.braintreepayments.cardform.view.CardEditText} for more details. Defaults to
      * {@code false}.
      */
-    public void setShouldMaskCardNumber(boolean maskCardNumber) {
-        shouldMaskCardNumber = maskCardNumber;
+    public void setMaskCardNumber(boolean maskCardNumber) {
+        this.maskCardNumber = maskCardNumber;
     }
 
     /**
@@ -140,8 +140,8 @@ public class DropInRequest implements Parcelable {
      *
      * @param maskSecurityCode {@code true} to mask the security code during input. Defaults to {@code false}.
      */
-    public void setShouldMaskSecurityCode(boolean maskSecurityCode) {
-        shouldMaskSecurityCode = maskSecurityCode;
+    public void setMaskSecurityCode(boolean maskSecurityCode) {
+        this.maskSecurityCode = maskSecurityCode;
     }
 
     /**
@@ -150,8 +150,8 @@ public class DropInRequest implements Parcelable {
      * @param vaultManager {@code true} to allow customers to manage their vaulted payment methods.
      * Defaults to {@code false}.
      */
-    public void setEnableVaultManager(boolean vaultManager) {
-        enableVaultManager = vaultManager;
+    public void setVaultManagerEnabled(boolean vaultManager) {
+        vaultManagerEnabled = vaultManager;
     }
 
     /**
@@ -206,14 +206,14 @@ public class DropInRequest implements Parcelable {
     /**
      * @return If Drop-in should collect and return device data for fraud prevention.
      */
-    public boolean getShouldCollectDeviceData() {
-        return shouldCollectDeviceData;
+    public boolean getCollectDeviceData() {
+        return collectDeviceData;
     }
 
     /**
      * @return If PayPal is disabled in Drop-in
      */
-    public boolean getPayPalDisabled() {
+    public boolean isPayPalDisabled() {
         return payPalDisabled;
     }
 
@@ -225,14 +225,14 @@ public class DropInRequest implements Parcelable {
     /**
      * @return If Venmo is disabled in Drop-in
      */
-    public boolean getVenmoDisabled() {
+    public boolean isVenmoDisabled() {
         return venmoDisabled;
     }
 
     /**
      * @return If card payments are disabled in Drop-in
      */
-    public boolean getCardDisabled() {
+    public boolean isCardDisabled() {
         return cardDisabled;
     }
 
@@ -246,14 +246,14 @@ public class DropInRequest implements Parcelable {
     /**
      * @return If Google Pay disabled in Drop-in
      */
-    public boolean getGooglePayDisabled() {
+    public boolean isGooglePayDisabled() {
         return googlePayDisabled;
     }
 
     /**
      * @return If a 3D Secure verification should be requested as part of Drop-in
      */
-    public boolean getShouldRequestThreeDSecureVerification() {
+    public boolean getRequestThreeDSecureVerification() {
         return requestThreeDSecureVerification;
     }
 
@@ -265,15 +265,15 @@ public class DropInRequest implements Parcelable {
     /**
      * @return If the card number field should be masked when the field is not focused.
      */
-    public boolean getShouldMaskCardNumber() {
-        return shouldMaskCardNumber;
+    public boolean getMaskCardNumber() {
+        return maskCardNumber;
     }
 
     /**
      * @return If the security code should be masked during input.
      */
-    public boolean getShouldMaskSecurityCode() {
-        return shouldMaskSecurityCode;
+    public boolean getMaskSecurityCode() {
+        return maskSecurityCode;
     }
 
     /**
@@ -284,8 +284,8 @@ public class DropInRequest implements Parcelable {
     /**
      * @return If vault manager is enabled to allow users manage their vaulted payment methods
      */
-    public boolean getEnableVaultManager() {
-        return enableVaultManager;
+    public boolean isVaultManagerEnabled() {
+        return vaultManagerEnabled;
     }
 
     /**
@@ -332,7 +332,7 @@ public class DropInRequest implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeByte(shouldCollectDeviceData ? (byte) 1 : (byte) 0);
+        dest.writeByte(collectDeviceData ? (byte) 1 : (byte) 0);
         dest.writeParcelable(googlePayRequest, 0);
         dest.writeByte(googlePayDisabled ? (byte) 1 : (byte) 0);
         dest.writeParcelable(payPalRequest, 0);
@@ -341,9 +341,9 @@ public class DropInRequest implements Parcelable {
         dest.writeByte(cardDisabled ? (byte) 1 : (byte) 0);
         dest.writeByte(requestThreeDSecureVerification ? (byte) 1 : (byte) 0);
         dest.writeParcelable(threeDSecureRequest, 0);
-        dest.writeByte(shouldMaskCardNumber ? (byte) 1 : (byte) 0);
-        dest.writeByte(shouldMaskSecurityCode ? (byte) 1 : (byte) 0);
-        dest.writeByte(enableVaultManager ? (byte) 1 : (byte) 0);
+        dest.writeByte(maskCardNumber ? (byte) 1 : (byte) 0);
+        dest.writeByte(maskSecurityCode ? (byte) 1 : (byte) 0);
+        dest.writeByte(vaultManagerEnabled ? (byte) 1 : (byte) 0);
         dest.writeInt(cardholderNameStatus);
         dest.writeByte(vaultCardDefaultValue ? (byte) 1 : (byte) 0);
         dest.writeByte(allowVaultCardOverride ? (byte) 1 : (byte) 0);
@@ -351,7 +351,7 @@ public class DropInRequest implements Parcelable {
     }
 
     protected DropInRequest(Parcel in) {
-        shouldCollectDeviceData = in.readByte() != 0;
+        collectDeviceData = in.readByte() != 0;
         googlePayRequest = in.readParcelable(GooglePayRequest.class.getClassLoader());
         googlePayDisabled = in.readByte() != 0;
         payPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
@@ -360,9 +360,9 @@ public class DropInRequest implements Parcelable {
         cardDisabled = in.readByte() != 0;
         requestThreeDSecureVerification = in.readByte() != 0;
         threeDSecureRequest = in.readParcelable(ThreeDSecureRequest.class.getClassLoader());
-        shouldMaskCardNumber = in.readByte() != 0;
-        shouldMaskSecurityCode = in.readByte() != 0;
-        enableVaultManager = in.readByte() != 0;
+        maskCardNumber = in.readByte() != 0;
+        maskSecurityCode = in.readByte() != 0;
+        vaultManagerEnabled = in.readByte() != 0;
         cardholderNameStatus = in.readInt();
         vaultCardDefaultValue = in.readByte() != 0;
         allowVaultCardOverride = in.readByte() != 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -23,13 +23,13 @@ public class DropInRequest implements Parcelable {
     private GooglePayRequest mGooglePaymentRequest;
     private PayPalRequest mPayPalRequest;
 
-    private boolean mGooglePaymentEnabled = true;
+    private boolean mGooglePaymentDisabled = false;
     private boolean mMaskCardNumber = false;
     private boolean mMaskSecurityCode = false;
     private boolean mVaultManagerEnabled = false;
-    private boolean mPayPalEnabled = true;
-    private boolean mVenmoEnabled = true;
-    private boolean mCardEnabled = true;
+    private boolean mPayPalDisabled = false;
+    private boolean mVenmoDisabled = false;
+    private boolean mCardDisabled = false;
     private boolean mDefaultVaultValue = true;
     private boolean mShowCheckBoxToAllowVaultOverride = false;
     private boolean mVaultVenmo = false;
@@ -73,32 +73,32 @@ public class DropInRequest implements Parcelable {
      * Disables Google Pay in Drop-in.
      * @param disableGooglePay
      */
-    public void setDisableGooglePay(boolean disableGooglePay) {
-        mGooglePaymentEnabled = !disableGooglePay;
+    public void setGooglePayDisabled(boolean disableGooglePay) {
+        mGooglePaymentDisabled = disableGooglePay;
     }
 
     /**
      * Disables PayPal in Drop-in.
      * @param disablePayPal
      */
-    public void setDisablePayPal(boolean disablePayPal) {
-        mPayPalEnabled = !disablePayPal;
+    public void setPayPalDisabled(boolean disablePayPal) {
+        mPayPalDisabled = disablePayPal;
     }
 
     /**
      * Disables Venmo in Drop-in.
      * @param disableVenmo
      */
-    public void setDisableVenmo(boolean disableVenmo) {
-        mVenmoEnabled = !disableVenmo;
+    public void setVenmoDisabled(boolean disableVenmo) {
+        mVenmoDisabled = disableVenmo;
     }
 
     /**
      * Disables Card in Drop-in.
      * @param disableCard
      */
-    public void setDisableCard(boolean disableCard) {
-        mCardEnabled = !disableCard;
+    public void setCardDisabled(boolean disableCard) {
+        mCardDisabled = disableCard;
     }
 
     /**
@@ -129,14 +129,14 @@ public class DropInRequest implements Parcelable {
      * See {@link com.braintreepayments.cardform.view.CardEditText} for more details. Defaults to
      * {@code false}.
      */
-    public void setMaskCardNumber(boolean maskCardNumber) {
+    public void setShouldMaskCardNumber(boolean maskCardNumber) {
         mMaskCardNumber = maskCardNumber;
     }
 
     /**
      * @param maskSecurityCode {@code true} to mask the security code during input. Defaults to {@code false}.
      */
-    public void setMaskSecurityCode(boolean maskSecurityCode) {
+    public void setShouldMaskSecurityCode(boolean maskSecurityCode) {
         mMaskSecurityCode = maskSecurityCode;
     }
 
@@ -205,48 +205,47 @@ public class DropInRequest implements Parcelable {
         return mAuthorization;
     }
 
-    boolean shouldCollectDeviceData() {
+    boolean getShouldCollectDeviceData() {
         return mCollectDeviceData;
     }
 
-    public boolean isPayPalEnabled() {
-        return mPayPalEnabled;
+    public boolean getPayPalDisabled() {
+        return mPayPalDisabled;
     }
 
     public PayPalRequest getPayPalRequest() { return mPayPalRequest; }
 
-    public boolean isVenmoEnabled() {
-        return mVenmoEnabled;
+    public boolean getVenmoDisabled() {
+        return mVenmoDisabled;
     }
 
-    public boolean isCardEnabled() {
-        return mCardEnabled;
+    public boolean getCardDisabled() {
+        return mCardDisabled;
     }
 
-    // TODO: rename to get GooglePayRequest
-    public GooglePayRequest getGooglePaymentRequest() {
+    public GooglePayRequest getGooglePayRequest() {
         return mGooglePaymentRequest;
     }
 
-    public boolean isGooglePaymentEnabled() {
-        return mGooglePaymentEnabled;
+    public boolean getGooglePayDisabled() {
+        return mGooglePaymentDisabled;
     }
 
-    boolean shouldRequestThreeDSecureVerification() {
+    boolean getShouldRequestThreeDSecureVerification() {
         return mRequestThreeDSecureVerification;
     }
 
     public ThreeDSecureRequest getThreeDSecureRequest() { return mThreeDSecureRequest; }
 
-    boolean shouldMaskCardNumber() {
+    boolean getShouldMaskCardNumber() {
         return mMaskCardNumber;
     }
 
-    boolean shouldMaskSecurityCode() {
+    boolean getShouldMaskSecurityCode() {
         return mMaskSecurityCode;
     }
 
-    boolean shouldVaultVenmo() { return mVaultVenmo; }
+    boolean getVaultVenmoDefaultValue() { return mVaultVenmo; }
 
     boolean getEnableVaultManager() {
         return mVaultManagerEnabled;
@@ -264,6 +263,22 @@ public class DropInRequest implements Parcelable {
         return mShowCheckBoxToAllowVaultOverride;
     }
 
+    boolean isPayPalEnabled() {
+        return !mPayPalDisabled;
+    }
+
+    boolean isVenmoEnabled() {
+        return !mVenmoDisabled;
+    }
+
+    boolean isGooglePayEnabled() {
+        return !mGooglePaymentDisabled;
+    }
+
+    boolean isCardEnabled() {
+        return !mCardDisabled;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -274,11 +289,11 @@ public class DropInRequest implements Parcelable {
         dest.writeString(mAuthorization);
         dest.writeByte(mCollectDeviceData ? (byte) 1 : (byte) 0);
         dest.writeParcelable(mGooglePaymentRequest, 0);
-        dest.writeByte(mGooglePaymentEnabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(mGooglePaymentDisabled ? (byte) 1 : (byte) 0);
         dest.writeParcelable(mPayPalRequest, 0);
-        dest.writeByte(mPayPalEnabled ? (byte) 1 : (byte) 0);
-        dest.writeByte(mVenmoEnabled ? (byte) 1 : (byte) 0);
-        dest.writeByte(mCardEnabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(mPayPalDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(mVenmoDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(mCardDisabled ? (byte) 1 : (byte) 0);
         dest.writeByte(mRequestThreeDSecureVerification ? (byte) 1 : (byte) 0);
         dest.writeParcelable(mThreeDSecureRequest, 0);
         dest.writeByte(mMaskCardNumber ? (byte) 1 : (byte) 0);
@@ -294,11 +309,11 @@ public class DropInRequest implements Parcelable {
         mAuthorization = in.readString();
         mCollectDeviceData = in.readByte() != 0;
         mGooglePaymentRequest = in.readParcelable(GooglePayRequest.class.getClassLoader());
-        mGooglePaymentEnabled = in.readByte() != 0;
+        mGooglePaymentDisabled = in.readByte() != 0;
         mPayPalRequest = in.readParcelable(PayPalRequest.class.getClassLoader());
-        mPayPalEnabled = in.readByte() != 0;
-        mVenmoEnabled = in.readByte() != 0;
-        mCardEnabled = in.readByte() != 0;
+        mPayPalDisabled = in.readByte() != 0;
+        mVenmoDisabled = in.readByte() != 0;
+        mCardDisabled = in.readByte() != 0;
         mRequestThreeDSecureVerification = in.readByte() != 0;
         mThreeDSecureRequest = in.readParcelable(ThreeDSecureRequest.class.getClassLoader());
         mMaskCardNumber = in.readByte() != 0;

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -40,30 +40,6 @@ public class DropInRequest implements Parcelable {
     public DropInRequest() {}
 
     /**
-     * Provide authorization allowing this client to communicate with Braintree. Either
-     * {@link #clientToken(String)} or {@link #tokenizationKey(String)} must be set or an
-     * {@link com.braintreepayments.api.AuthenticationException} will occur.
-     *
-     * @param clientToken The client token to use for the request.
-     */
-    public DropInRequest clientToken(String clientToken) {
-        mAuthorization = clientToken;
-        return this;
-    }
-
-    /**
-     * Provide authorization allowing this client to communicate with Braintree. Either
-     * {@link #clientToken(String)} or {@link #tokenizationKey(String)} must be set or an
-     * {@link com.braintreepayments.api.AuthenticationException} will occur.
-     *
-     * @param tokenizationKey The tokenization key to use for the request.
-     */
-    public DropInRequest tokenizationKey(String tokenizationKey) {
-        mAuthorization = tokenizationKey;
-        return this;
-    }
-
-    /**
      * Deprecated. Use {@link ThreeDSecureRequest#setAmount(String)}
      *
      * This method is optional. Amount is only used for 3D Secure verifications.

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
@@ -89,7 +89,7 @@ public class DropInResult implements Parcelable {
 
     /**
      * @return {@link String} of device data. Returned when specified with
-     * {@link DropInRequest#collectDeviceData(boolean)} that device data should be collected.
+     * {@link DropInRequest#setShouldCollectDeviceData(boolean)} that device data should be collected.
      */
     @Nullable
     public String getDeviceData() {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
@@ -89,7 +89,7 @@ public class DropInResult implements Parcelable {
 
     /**
      * @return {@link String} of device data. Returned when specified with
-     * {@link DropInRequest#setShouldCollectDeviceData(boolean)} that device data should be collected.
+     * {@link DropInRequest#setCollectDeviceData(boolean)} that device data should be collected.
      */
     @Nullable
     public String getDeviceData() {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
@@ -20,6 +20,13 @@ public class DropInResult implements Parcelable {
     public static final String EXTRA_DROP_IN_RESULT =
             "com.braintreepayments.api.dropin.EXTRA_DROP_IN_RESULT";
 
+    /**
+     * Errors are returned as the serializable value of this key in the data intent in
+     * {#onActivityResult(int, int, android.content.Intent)} if responseCode is not {RESULT_OK} or
+     * {RESULT_CANCELED}.
+     */
+    public static final String EXTRA_ERROR = "com.braintreepayments.api.dropin.EXTRA_ERROR";
+
     static final String LAST_USED_PAYMENT_METHOD_TYPE =
             "com.braintreepayments.api.dropin.LAST_USED_PAYMENT_METHOD_TYPE";
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -181,7 +181,7 @@ public class SupportedPaymentMethodsFragment extends Fragment implements Support
 
             mVaultedPaymentMethodsView.setAdapter(vaultedPaymentMethodsAdapter);
 
-            if (dropInRequest.getEnableVaultManager()) {
+            if (dropInRequest.isVaultManagerEnabled()) {
                 mVaultManagerButton.setVisibility(View.VISIBLE);
             }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -5,12 +5,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DividerItemDecoration;
@@ -183,7 +181,7 @@ public class SupportedPaymentMethodsFragment extends Fragment implements Support
 
             mVaultedPaymentMethodsView.setAdapter(vaultedPaymentMethodsAdapter);
 
-            if (dropInRequest.isVaultManagerEnabled()) {
+            if (dropInRequest.getEnableVaultManager()) {
                 mVaultManagerButton.setVisibility(View.VISIBLE);
             }
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/AvailablePaymentMethodNonceListUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/AvailablePaymentMethodNonceListUnitTest.java
@@ -76,7 +76,7 @@ public class AvailablePaymentMethodNonceListUnitTest {
     public void cardsNotAvailableIfDisableInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, true, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableCard(true);
+        dropInRequest.setCardDisabled(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) cardNonce);
 
@@ -90,7 +90,7 @@ public class AvailablePaymentMethodNonceListUnitTest {
     public void paypalNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(true, false, false, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisablePayPal(true);
+        dropInRequest.setPayPalDisabled(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) payPalAccountNonce);
 
@@ -104,7 +104,7 @@ public class AvailablePaymentMethodNonceListUnitTest {
     public void venmoNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, true, false, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableVenmo(true);
+        dropInRequest.setVenmoDisabled(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) venmoAccountNonce);
 
@@ -118,7 +118,7 @@ public class AvailablePaymentMethodNonceListUnitTest {
     public void googlePaymentNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, false, true);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) googlePaymentCardNonce);
 
@@ -132,7 +132,7 @@ public class AvailablePaymentMethodNonceListUnitTest {
     public void googlePayNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, false, true);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) googlePaymentCardNonce);
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/AvailablePaymentMethodNonceListUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/AvailablePaymentMethodNonceListUnitTest.java
@@ -75,8 +75,8 @@ public class AvailablePaymentMethodNonceListUnitTest {
     @Test
     public void cardsNotAvailableIfDisableInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, true, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableCard();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableCard(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) cardNonce);
 
@@ -89,8 +89,8 @@ public class AvailablePaymentMethodNonceListUnitTest {
     @Test
     public void paypalNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(true, false, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disablePayPal();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisablePayPal(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) payPalAccountNonce);
 
@@ -103,8 +103,8 @@ public class AvailablePaymentMethodNonceListUnitTest {
     @Test
     public void venmoNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, true, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableVenmo();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableVenmo(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) venmoAccountNonce);
 
@@ -117,8 +117,8 @@ public class AvailablePaymentMethodNonceListUnitTest {
     @Test
     public void googlePaymentNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, false, true);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableGooglePayment();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableGooglePay(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) googlePaymentCardNonce);
 
@@ -131,8 +131,8 @@ public class AvailablePaymentMethodNonceListUnitTest {
     @Test
     public void googlePayNotAvailableIfDisabledInDropInRequest() {
         Configuration configuration = getMockConfiguration(false, false, false, true);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableGooglePayment();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableGooglePay(true);
 
         List<PaymentMethodNonce> paymentMethodNonces = Collections.singletonList((PaymentMethodNonce) googlePaymentCardNonce);
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
@@ -31,7 +31,6 @@ public class BaseActivityUnitTest {
     @Test
     public void onCreate_setsDropInRequest() {
         Intent intent = new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .getIntent(RuntimeEnvironment.application);
         mActivityController = Robolectric.buildActivity(BaseActivity.class, intent);
         mActivity = (BaseActivity) mActivityController.get();
@@ -41,13 +40,11 @@ public class BaseActivityUnitTest {
         mActivityController.create();
 
         assertNotNull(mActivity.mDropInRequest);
-        assertEquals(TOKENIZATION_KEY, mActivity.mDropInRequest.getAuthorization());
     }
 
     @Test
     public void getDropInClient_returnsADropInClient() {
         setup(new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .getIntent(RuntimeEnvironment.application));
 
         assertNotNull(mActivity.getDropInClient());
@@ -56,7 +53,6 @@ public class BaseActivityUnitTest {
     @Test
     public void getDropInClient_setsClientTokenPresentWhenAClientTokenIsNotPresent() {
         setup(new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .getIntent(RuntimeEnvironment.application));
 
         mActivity.getDropInClient();
@@ -69,7 +65,6 @@ public class BaseActivityUnitTest {
             throws JSONException {
         CardNonce cardNonce = CardNonce.fromJSON(new JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE));
         setup(new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .getIntent(RuntimeEnvironment.application));
 
         mActivity.finish(cardNonce, "device_data");
@@ -88,7 +83,6 @@ public class BaseActivityUnitTest {
     public void finish_finishesWithException() {
         Exception exception = new Exception("Error message");
         setup(new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .getIntent(RuntimeEnvironment.application));
 
         mActivity.finish(exception);

--- a/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
@@ -8,13 +8,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
 
 import static androidx.appcompat.app.AppCompatActivity.RESULT_FIRST_USER;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_OK;
-import static com.braintreepayments.api.TestTokenizationKey.TOKENIZATION_KEY;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -30,8 +28,8 @@ public class BaseActivityUnitTest {
 
     @Test
     public void onCreate_setsDropInRequest() {
-        Intent intent = new DropInRequest()
-                .getIntent(RuntimeEnvironment.application);
+        Intent intent = new Intent();
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, new DropInRequest());
         mActivityController = Robolectric.buildActivity(BaseActivity.class, intent);
         mActivity = (BaseActivity) mActivityController.get();
 
@@ -44,16 +42,18 @@ public class BaseActivityUnitTest {
 
     @Test
     public void getDropInClient_returnsADropInClient() {
-        setup(new DropInRequest()
-                .getIntent(RuntimeEnvironment.application));
+        Intent intent = new Intent();
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, new DropInRequest());
+        setup(intent);
 
         assertNotNull(mActivity.getDropInClient());
     }
 
     @Test
     public void getDropInClient_setsClientTokenPresentWhenAClientTokenIsNotPresent() {
-        setup(new DropInRequest()
-                .getIntent(RuntimeEnvironment.application));
+        Intent intent = new Intent();
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, new DropInRequest());
+        setup(intent);
 
         mActivity.getDropInClient();
 
@@ -64,8 +64,9 @@ public class BaseActivityUnitTest {
     public void finish_finishesWithPaymentMethodNonceAndDeviceDataInDropInResult()
             throws JSONException {
         CardNonce cardNonce = CardNonce.fromJSON(new JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE));
-        setup(new DropInRequest()
-                .getIntent(RuntimeEnvironment.application));
+        Intent intent = new Intent();
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, new DropInRequest());
+        setup(intent);
 
         mActivity.finish(cardNonce, "device_data");
 
@@ -82,8 +83,9 @@ public class BaseActivityUnitTest {
     @Test
     public void finish_finishesWithException() {
         Exception exception = new Exception("Error message");
-        setup(new DropInRequest()
-                .getIntent(RuntimeEnvironment.application));
+        Intent intent = new Intent();
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, new DropInRequest());
+        setup(intent);
 
         mActivity.finish(exception);
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/BaseActivityUnitTest.java
@@ -91,7 +91,7 @@ public class BaseActivityUnitTest {
         assertTrue(mActivity.isFinishing());
         assertEquals(RESULT_FIRST_USER, shadowActivity.getResultCode());
         Exception error = (Exception) shadowActivity.getResultIntent()
-                .getSerializableExtra(DropInActivity.EXTRA_ERROR);
+                .getSerializableExtra(DropInResult.EXTRA_ERROR);
         assertNotNull(error);
         assertEquals("Error message", error.getMessage());
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -256,7 +256,7 @@ public class DropInActivityUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         String authorization = Fixtures.TOKENIZATION_KEY;
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
@@ -386,7 +386,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_returnsDeviceData() throws JSONException {
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
 
         String authorization = Fixtures.TOKENIZATION_KEY;
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -7,7 +7,6 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
@@ -20,7 +19,6 @@ import java.util.Objects;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_CANCELED;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_FIRST_USER;
 import static androidx.appcompat.app.AppCompatActivity.RESULT_OK;
-import static com.braintreepayments.api.TestTokenizationKey.TOKENIZATION_KEY;
 import static com.braintreepayments.api.UnitTestFixturesHelper.base64EncodedClientTokenFromFixture;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -256,9 +254,9 @@ public class DropInActivityUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         String authorization = Fixtures.TOKENIZATION_KEY;
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
@@ -387,8 +385,8 @@ public class DropInActivityUnitTest {
 
     @Test
     public void onVaultedPaymentMethodSelected_returnsDeviceData() throws JSONException {
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
 
         String authorization = Fixtures.TOKENIZATION_KEY;
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -72,7 +72,7 @@ public class DropInActivityUnitTest {
 
         assertEquals(RESULT_FIRST_USER, mShadowActivity.getResultCode());
         Exception exception = (Exception) mShadowActivity.getResultIntent()
-                .getSerializableExtra(DropInActivity.EXTRA_ERROR);
+                .getSerializableExtra(DropInResult.EXTRA_ERROR);
         assertTrue(exception instanceof InvalidArgumentException);
         assertEquals("Tokenization Key or Client Token was invalid.", exception.getMessage());
     }
@@ -625,7 +625,7 @@ public class DropInActivityUnitTest {
         assertTrue(mActivity.isFinishing());
         assertEquals(RESULT_FIRST_USER, mShadowActivity.getResultCode());
         Exception actualException = (Exception) mShadowActivity.getResultIntent()
-                .getSerializableExtra(DropInActivity.EXTRA_ERROR);
+                .getSerializableExtra(DropInResult.EXTRA_ERROR);
         assertEquals(exception.getClass(), actualException.getClass());
         assertEquals(exception.getMessage(), actualException.getMessage());
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.java
@@ -62,7 +62,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onCreate_whenAuthorizationIsInvalid_finishesWithError() {
         String authorization = "not a tokenization key";
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = mock(DropInClient.class);
         when(dropInClient.getAuthorization()).thenReturn(mock(InvalidAuthorization.class));
@@ -80,7 +80,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onResume_deliversBrowserSwitchResult() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = mock(DropInClient.class);
 
@@ -93,7 +93,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onResume_whenBrowserSwitchResultExists_finishesActivity() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInResult result = mock(DropInResult.class);
         PaymentMethodNonce nonce = mock(PaymentMethodNonce.class);
@@ -113,7 +113,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onResume_whenBrowserSwitchReturnsUserCanceledException_setsUserCanceledErrorInViewModel() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         Exception error = new UserCanceledException("User canceled 3DS.");
         DropInClient dropInClient = new MockDropInClientBuilder()
@@ -132,7 +132,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onResume_whenBrowserSwitchError_forwardsError() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         Exception error = new Exception("A 3DS error");
         DropInClient dropInClient = new MockDropInClientBuilder()
@@ -151,7 +151,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onActivityResult_whenDropInResultExists_finishesActivity() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInResult result = mock(DropInResult.class);
         PaymentMethodNonce nonce = mock(PaymentMethodNonce.class);
@@ -171,7 +171,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onActivityResult_whenResultIsUserCanceledException_setsUserCanceledErrorInViewModel() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         Exception error = new UserCanceledException("User canceled 3DS.");
         DropInClient dropInClient = new MockDropInClientBuilder()
@@ -190,7 +190,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onActivityResult_whenError_handlesError() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         Exception error = new Exception("A 3DS error");
         DropInClient dropInClient = new MockDropInClientBuilder()
@@ -209,7 +209,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onActivityResult_forwardsResultToDropInClient() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .build();
@@ -226,7 +226,7 @@ public class DropInActivityUnitTest {
     @Test
     public void setsIntegrationTypeToDropinForDropinActivity() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
         setupDropInActivity(authorization, mock(DropInClient.class), dropInRequest, "sessionId");
         mActivityController.setup();
 
@@ -238,7 +238,7 @@ public class DropInActivityUnitTest {
     @Test
     public void sendsAnalyticsEventWhenShown() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
         setupDropInActivity(authorization, mock(DropInClient.class), dropInRequest, "sessionId");
         mActivityController.setup();
 
@@ -248,6 +248,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_reloadsPaymentMethodsIfThreeDSecureVerificationFails() throws JSONException {
         DropInClient dropInClient = new MockDropInClientBuilder()
+                .authorization(Authorization.fromString(base64EncodedClientTokenFromFixture(Fixtures.CLIENT_TOKEN)))
                 .threeDSecureError(new Exception("three d secure failure"))
                 .shouldPerformThreeDSecureVerification(true)
                 .build();
@@ -256,7 +257,6 @@ public class DropInActivityUnitTest {
         threeDSecureRequest.setAmount("1.00");
 
         DropInRequest dropInRequest = new DropInRequest()
-                .clientToken(base64EncodedClientTokenFromFixture(Fixtures.CLIENT_TOKEN))
                 .threeDSecureRequest(threeDSecureRequest)
                 .requestThreeDSecureVerification(true);
 
@@ -276,7 +276,7 @@ public class DropInActivityUnitTest {
     @Test
     public void pressingBackExitsActivityWithResultCanceled() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
         setupDropInActivity(authorization, mock(DropInClient.class), dropInRequest, "sessionId");
         mActivityController.setup();
 
@@ -289,7 +289,7 @@ public class DropInActivityUnitTest {
     @Test
     public void pressingBackSendsAnalyticsEvent() {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .build();
@@ -304,7 +304,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_whenShouldNotRequestThreeDSecureVerification_returnsANonce() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .shouldPerformThreeDSecureVerification(false)
@@ -328,7 +328,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentSelected_requestsThreeDSecureVerificationForCardWhenEnabled() throws Exception {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .shouldPerformThreeDSecureVerification(true)
@@ -346,7 +346,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_sendsAnAnalyticsEvent() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -369,7 +369,7 @@ public class DropInActivityUnitTest {
                 .build();
 
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
         setupDropInActivity(authorization, dropInClient, dropInRequest, "sessionId");
         mActivityController.setup();
 
@@ -388,7 +388,6 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_returnsDeviceData() throws JSONException {
         DropInRequest dropInRequest = new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .collectDeviceData(true);
 
         String authorization = Fixtures.TOKENIZATION_KEY;
@@ -417,7 +416,7 @@ public class DropInActivityUnitTest {
     @Test
     public void selectingAVaultedPaymentMethod_returnsANonce() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         List<PaymentMethodNonce> nonces = new ArrayList<>();
         PaymentMethodNonce paymentMethodNonce = PayPalAccountNonce.fromJSON(new JSONObject(Fixtures.PAYPAL_ACCOUNT_JSON));
@@ -446,7 +445,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_whenCard_sendsAnalyticEvent() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .build();
@@ -463,7 +462,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onVaultedPaymentMethodSelected_whenPayPal_doesNotSendAnalyticEvent() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .build();
@@ -528,7 +527,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onSupportedPaymentMethodSelected_withTypePayPal_tokenizesPayPal() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .authorization(Authorization.fromString(authorization))
@@ -548,7 +547,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onSupportedPaymentMethodSelected_withTypeVenmo_tokenizesVenmo() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .authorization(Authorization.fromString(authorization))
@@ -568,7 +567,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onSupportedPaymentMethodSelected_withTypeGooglePay_requestsGooglePay() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .authorization(Authorization.fromString(authorization))
@@ -588,7 +587,7 @@ public class DropInActivityUnitTest {
     @Test
     public void onSupportedPaymentMethodSelected_withTypeUnknown_showsAddCardFragment() throws JSONException {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .authorization(Authorization.fromString(authorization))
@@ -613,7 +612,7 @@ public class DropInActivityUnitTest {
 
     private void assertExceptionIsReturned(String analyticsEvent, Exception exception) {
         String authorization = Fixtures.TOKENIZATION_KEY;
-        DropInRequest dropInRequest = new DropInRequest().tokenizationKey(authorization);
+        DropInRequest dropInRequest = new DropInRequest();
 
         DropInClient dropInClient = new MockDropInClientBuilder()
                 .build();

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -168,7 +168,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -841,7 +841,7 @@ public class DropInClientUnitTest {
     public void getSupportedPaymentMethods_whenCardsDisabledInDropInRequest_doesNotReturnCards() {
         Configuration configuration = mockConfiguration(false, false, true, false, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableCard(true);
+        dropInRequest.setCardDisabled(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -870,7 +870,7 @@ public class DropInClientUnitTest {
     public void getSupportedPaymentMethods_whenPayPalDisabledInDropInRequest_doesNotReturnPayPal() {
         Configuration configuration = mockConfiguration(true, false, false, false, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisablePayPal(true);
+        dropInRequest.setPayPalDisabled(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -899,7 +899,7 @@ public class DropInClientUnitTest {
     public void getSupportedPaymentMethods_whenVenmoDisabledInDropInRequest_doesNotReturnVenmo() {
         Configuration configuration = mockConfiguration(false, true, false, false, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableVenmo(true);
+        dropInRequest.setVenmoDisabled(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -928,7 +928,7 @@ public class DropInClientUnitTest {
     public void getSupportedPaymentMethods_whenGooglePayDisabledInDropInRequest_doesNotReturnGooglePay() {
         Configuration configuration = mockConfiguration(false, false, false, true, false);
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -1586,7 +1586,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -213,7 +213,7 @@ public class DropInClientUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -240,7 +240,7 @@ public class DropInClientUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -267,7 +267,7 @@ public class DropInClientUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -294,7 +294,7 @@ public class DropInClientUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -320,7 +320,7 @@ public class DropInClientUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -409,7 +409,7 @@ public class DropInClientUnitTest {
     public void performThreeDSecureVerification_whenShouldNotCollectDeviceData_continuesThreeDSecureVerificationAndCallsBackResultWithNonce() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         ThreeDSecureResult performVerificationResult = new ThreeDSecureResult();
@@ -446,7 +446,7 @@ public class DropInClientUnitTest {
     public void performThreeDSecureVerification_whenShouldCollectDeviceData_includesDeviceDataInResult() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         ThreeDSecureResult performVerificationResult = new ThreeDSecureResult();
@@ -488,7 +488,7 @@ public class DropInClientUnitTest {
     public void performThreeDSecureVerification_whenShouldCollectDeviceDataAndDataCollectionFails_callsBackAnError() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         CardNonce cardNonce = CardNonce.fromJSON(new JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE));
@@ -1169,7 +1169,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1209,7 +1209,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1248,7 +1248,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1283,7 +1283,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1327,7 +1327,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1366,7 +1366,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1401,7 +1401,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1442,7 +1442,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1478,7 +1478,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1509,7 +1509,7 @@ public class DropInClientUnitTest {
                 .build();
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setEnableVaultManager(true);
+        dropInRequest.setVaultManagerEnabled(true);
 
         DropInClientParams params = new DropInClientParams()
                 .braintreeClient(braintreeClient)
@@ -1528,7 +1528,7 @@ public class DropInClientUnitTest {
         assertEquals("authorization", intent.getStringExtra(DropInClient.EXTRA_AUTHORIZATION));
 
         DropInRequest dropInRequestExtra = intent.getParcelableExtra(DropInClient.EXTRA_CHECKOUT_REQUEST);
-        assertTrue(dropInRequestExtra.getEnableVaultManager());
+        assertTrue(dropInRequestExtra.isVaultManagerEnabled());
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 
 import androidx.fragment.app.FragmentActivity;
 
-import org.apache.tools.ant.types.Commandline;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -168,8 +167,8 @@ public class DropInClientUnitTest {
                 .configuration(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY))
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableGooglePayment();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableGooglePay(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -212,9 +211,9 @@ public class DropInClientUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -239,9 +238,9 @@ public class DropInClientUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -266,9 +265,9 @@ public class DropInClientUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -293,9 +292,9 @@ public class DropInClientUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -319,9 +318,9 @@ public class DropInClientUnitTest {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
         threeDSecureRequest.setAmount("1.00");
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest)
-                .requestThreeDSecureVerification(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)
@@ -362,8 +361,8 @@ public class DropInClientUnitTest {
     @Test
     public void performThreeDSecureVerification_performsVerificationAndSetsNonceOnThreeDSecureRequest() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         ThreeDSecureClient threeDSecureClient = new MockThreeDSecureClientBuilder().build();
         DropInClientParams params = new DropInClientParams()
@@ -384,8 +383,8 @@ public class DropInClientUnitTest {
     @Test
     public void performThreeDSecureVerification_whenVerificationFails_callbackError() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .threeDSecureRequest(threeDSecureRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         Exception performVerificationError = new Exception("verification error");
         ThreeDSecureClient threeDSecureClient = new MockThreeDSecureClientBuilder()
@@ -409,9 +408,9 @@ public class DropInClientUnitTest {
     @Test
     public void performThreeDSecureVerification_whenShouldNotCollectDeviceData_continuesThreeDSecureVerificationAndCallsBackResultWithNonce() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false)
-                .threeDSecureRequest(threeDSecureRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         ThreeDSecureResult performVerificationResult = new ThreeDSecureResult();
 
@@ -446,9 +445,9 @@ public class DropInClientUnitTest {
     @Test
     public void performThreeDSecureVerification_whenShouldCollectDeviceData_includesDeviceDataInResult() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true)
-                .threeDSecureRequest(threeDSecureRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         ThreeDSecureResult performVerificationResult = new ThreeDSecureResult();
 
@@ -488,9 +487,9 @@ public class DropInClientUnitTest {
     @Test
     public void performThreeDSecureVerification_whenShouldCollectDeviceDataAndDataCollectionFails_callsBackAnError() throws JSONException {
         ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true)
-                .threeDSecureRequest(threeDSecureRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
 
         CardNonce cardNonce = CardNonce.fromJSON(new JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE));
         ThreeDSecureResult performVerificationResult = new ThreeDSecureResult();
@@ -841,8 +840,8 @@ public class DropInClientUnitTest {
     @Test
     public void getSupportedPaymentMethods_whenCardsDisabledInDropInRequest_doesNotReturnCards() {
         Configuration configuration = mockConfiguration(false, false, true, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableCard();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableCard(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -870,8 +869,8 @@ public class DropInClientUnitTest {
     @Test
     public void getSupportedPaymentMethods_whenPayPalDisabledInDropInRequest_doesNotReturnPayPal() {
         Configuration configuration = mockConfiguration(true, false, false, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disablePayPal();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisablePayPal(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -899,8 +898,8 @@ public class DropInClientUnitTest {
     @Test
     public void getSupportedPaymentMethods_whenVenmoDisabledInDropInRequest_doesNotReturnVenmo() {
         Configuration configuration = mockConfiguration(false, true, false, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableVenmo();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableVenmo(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -928,8 +927,8 @@ public class DropInClientUnitTest {
     @Test
     public void getSupportedPaymentMethods_whenGooglePayDisabledInDropInRequest_doesNotReturnGooglePay() {
         Configuration configuration = mockConfiguration(false, false, false, true, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableGooglePayment();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableGooglePay(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -982,8 +981,8 @@ public class DropInClientUnitTest {
     public void tokenizePayPalAccount_withPayPalCheckoutRequest_tokenizesPayPalWithCheckoutRequest() {
         Configuration configuration = mockConfiguration(true, false, false, false, false);
         PayPalCheckoutRequest payPalRequest = new PayPalCheckoutRequest("1.00");
-        DropInRequest dropInRequest = new DropInRequest()
-                .paypalRequest(payPalRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setPayPalRequest(payPalRequest);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -1008,8 +1007,8 @@ public class DropInClientUnitTest {
     public void tokenizePayPalAccount_withPayPalVaultRequest_tokenizesPayPalWithVaultRequest() {
         Configuration configuration = mockConfiguration(true, false, false, false, false);
         PayPalVaultRequest payPalRequest = new PayPalVaultRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .paypalRequest(payPalRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setPayPalRequest(payPalRequest);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -1033,8 +1032,8 @@ public class DropInClientUnitTest {
     @Test
     public void tokenizeVenmoAccount_tokenizesVenmo() {
         Configuration configuration = mockConfiguration(false, true, false, false, false);
-        DropInRequest dropInRequest = new DropInRequest()
-                .vaultVenmo(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setVaultVenmoDefaultValue(true);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -1065,8 +1064,8 @@ public class DropInClientUnitTest {
         Configuration configuration = mockConfiguration(false, false, false, true, false);
 
         GooglePayRequest googlePayRequest = new GooglePayRequest();
-        DropInRequest dropInRequest = new DropInRequest()
-                .googlePaymentRequest(googlePayRequest);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setGooglePayRequest(googlePayRequest);
 
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder()
                 .authorization(Authorization.fromString(Fixtures.BASE64_CLIENT_TOKEN))
@@ -1169,8 +1168,8 @@ public class DropInClientUnitTest {
                 .browserSwitchResult(payPalAccountNonce)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1209,8 +1208,8 @@ public class DropInClientUnitTest {
                 .browserSwitchResult(payPalAccountNonce)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1248,8 +1247,8 @@ public class DropInClientUnitTest {
                 .browserSwitchError(browserSwitchError)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1283,8 +1282,8 @@ public class DropInClientUnitTest {
                 .browserSwitchResult(threeDSecureResult)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1327,8 +1326,8 @@ public class DropInClientUnitTest {
                 .browserSwitchResult(threeDSecureResult)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1366,8 +1365,8 @@ public class DropInClientUnitTest {
                 .browserSwitchError(browserSwitchError)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1401,8 +1400,8 @@ public class DropInClientUnitTest {
                 .activityResult(threeDSecureResult)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1442,8 +1441,8 @@ public class DropInClientUnitTest {
                 .activityResult(threeDSecureResult)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
 
         DataCollector dataCollector = new MockDataCollectorBuilder()
                 .collectDeviceDataSuccess("device data")
@@ -1478,8 +1477,8 @@ public class DropInClientUnitTest {
                 .activityResultError(activityResultError)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(false);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(false);
 
         DataCollector dataCollector = mock(DataCollector.class);
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
@@ -1509,7 +1508,9 @@ public class DropInClientUnitTest {
                 .authorization(authorization)
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest().vaultManager(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setEnableVaultManager(true);
+
         DropInClientParams params = new DropInClientParams()
                 .braintreeClient(braintreeClient)
                 .dropInRequest(dropInRequest);
@@ -1527,7 +1528,7 @@ public class DropInClientUnitTest {
         assertEquals("authorization", intent.getStringExtra(DropInClient.EXTRA_AUTHORIZATION));
 
         DropInRequest dropInRequestExtra = intent.getParcelableExtra(DropInClient.EXTRA_CHECKOUT_REQUEST);
-        assertTrue(dropInRequestExtra.isVaultManagerEnabled());
+        assertTrue(dropInRequestExtra.getEnableVaultManager());
     }
 
     @Test
@@ -1584,8 +1585,8 @@ public class DropInClientUnitTest {
                 .getPaymentMethodNoncesSuccess(Collections.singletonList(cardNonce))
                 .build();
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .disableGooglePayment();
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setDisableGooglePay(true);
 
         DropInClientParams params = new DropInClientParams()
                 .dropInRequest(dropInRequest)

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -59,36 +59,36 @@ public class DropInRequestUnitTest {
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setShouldCollectDeviceData(true);
         dropInRequest.setGooglePayRequest(googlePayRequest);
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
         dropInRequest.setPayPalRequest(paypalRequest);
-        dropInRequest.setDisablePayPal(true);
-        dropInRequest.setDisableVenmo(true);
-        dropInRequest.setDisableCard(true);
+        dropInRequest.setPayPalDisabled(true);
+        dropInRequest.setVenmoDisabled(true);
+        dropInRequest.setCardDisabled(true);
         dropInRequest.setShouldRequestThreeDSecureVerification(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setMaskCardNumber(true);
-        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setShouldMaskCardNumber(true);
+        dropInRequest.setShouldMaskSecurityCode(true);
         dropInRequest.setEnableVaultManager(true);
         dropInRequest.setAllowVaultCardOverride(true);
         dropInRequest.setVaultCardDefaultValue(true);
         dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
         dropInRequest.setVaultVenmoDefaultValue(true);
 
-        assertTrue(dropInRequest.shouldCollectDeviceData());
-        assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
-        assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
-        assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPriceStatus());
-        assertTrue(dropInRequest.getGooglePaymentRequest().isEmailRequired());
-        assertFalse(dropInRequest.isGooglePaymentEnabled());
+        assertTrue(dropInRequest.getShouldCollectDeviceData());
+        assertEquals("10", dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPrice());
+        assertEquals("USD", dropInRequest.getGooglePayRequest().getTransactionInfo().getCurrencyCode());
+        assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPriceStatus());
+        assertTrue(dropInRequest.getGooglePayRequest().isEmailRequired());
+        assertFalse(dropInRequest.getGooglePayDisabled());
 
         PayPalCheckoutRequest checkoutRequest = (PayPalCheckoutRequest) dropInRequest.getPayPalRequest();
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertFalse(dropInRequest.isPayPalEnabled());
-        assertFalse(dropInRequest.isVenmoEnabled());
-        assertFalse(dropInRequest.isCardEnabled());
-        assertTrue(dropInRequest.shouldRequestThreeDSecureVerification());
+        assertFalse(dropInRequest.getPayPalDisabled());
+        assertFalse(dropInRequest.getVenmoDisabled());
+        assertFalse(dropInRequest.getCardDisabled());
+        assertTrue(dropInRequest.getShouldRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());
         assertEquals("10.00", dropInRequest.getThreeDSecureRequest().getAmount());
@@ -104,13 +104,13 @@ public class DropInRequestUnitTest {
         assertEquals("US", dropInRequest.getThreeDSecureRequest().getBillingAddress().getCountryCodeAlpha2());
         assertEquals("3125557890", dropInRequest.getThreeDSecureRequest().getBillingAddress().getPhoneNumber());
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
-        assertTrue(dropInRequest.shouldMaskCardNumber());
-        assertTrue(dropInRequest.shouldMaskSecurityCode());
+        assertTrue(dropInRequest.getShouldMaskCardNumber());
+        assertTrue(dropInRequest.getShouldMaskSecurityCode());
         assertTrue(dropInRequest.getEnableVaultManager());
         assertTrue(dropInRequest.getVaultCardDefaultValue());
         assertTrue(dropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, dropInRequest.getCardholderNameStatus());
-        assertTrue(dropInRequest.shouldVaultVenmo());
+        assertTrue(dropInRequest.getVaultVenmoDefaultValue());
     }
 
     @Test
@@ -122,20 +122,20 @@ public class DropInRequestUnitTest {
 
         assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
         assertNull(dropInRequest.getAuthorization());
-        assertFalse(dropInRequest.shouldCollectDeviceData());
-        assertTrue(dropInRequest.isGooglePaymentEnabled());
+        assertFalse(dropInRequest.getShouldCollectDeviceData());
+        assertTrue(dropInRequest.getGooglePayDisabled());
         assertNull(dropInRequest.getPayPalRequest());
-        assertTrue(dropInRequest.isPayPalEnabled());
-        assertTrue(dropInRequest.isVenmoEnabled());
-        assertTrue(dropInRequest.isCardEnabled());
-        assertFalse(dropInRequest.shouldRequestThreeDSecureVerification());
+        assertTrue(dropInRequest.getPayPalDisabled());
+        assertTrue(dropInRequest.getVenmoDisabled());
+        assertTrue(dropInRequest.getCardDisabled());
+        assertFalse(dropInRequest.getShouldRequestThreeDSecureVerification());
         assertNull(dropInRequest.getThreeDSecureRequest());
-        assertFalse(dropInRequest.shouldMaskCardNumber());
-        assertFalse(dropInRequest.shouldMaskSecurityCode());
+        assertFalse(dropInRequest.getShouldMaskCardNumber());
+        assertFalse(dropInRequest.getShouldMaskSecurityCode());
         assertFalse(dropInRequest.getEnableVaultManager());
         assertFalse(dropInRequest.getAllowVaultCardOverride());
         assertTrue(dropInRequest.getVaultCardDefaultValue());
-        assertFalse(dropInRequest.shouldVaultVenmo());
+        assertFalse(dropInRequest.getVaultVenmoDefaultValue());
         assertEquals(CardForm.FIELD_DISABLED, dropInRequest.getCardholderNameStatus());
     }
 
@@ -178,15 +178,15 @@ public class DropInRequestUnitTest {
         DropInRequest dropInRequest = new DropInRequest();
         dropInRequest.setShouldCollectDeviceData(true);
         dropInRequest.setGooglePayRequest(googlePayRequest);
-        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setGooglePayDisabled(true);
         dropInRequest.setPayPalRequest(paypalRequest);
-        dropInRequest.setDisablePayPal(true);
-        dropInRequest.setDisableVenmo(true);
-        dropInRequest.setDisableCard(true);
+        dropInRequest.setPayPalDisabled(true);
+        dropInRequest.setVenmoDisabled(true);
+        dropInRequest.setCardDisabled(true);
         dropInRequest.setShouldRequestThreeDSecureVerification(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setMaskCardNumber(true);
-        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setShouldMaskCardNumber(true);
+        dropInRequest.setShouldMaskSecurityCode(true);
         dropInRequest.setEnableVaultManager(true);
         dropInRequest.setAllowVaultCardOverride(true);
         dropInRequest.setVaultCardDefaultValue(true);
@@ -198,21 +198,21 @@ public class DropInRequestUnitTest {
         parcel.setDataPosition(0);
         DropInRequest parceledDropInRequest = DropInRequest.CREATOR.createFromParcel(parcel);
 
-        assertTrue(parceledDropInRequest.shouldCollectDeviceData());
-        assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
-        assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
-        assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPriceStatus());
-        assertTrue(dropInRequest.getGooglePaymentRequest().isEmailRequired());
+        assertTrue(parceledDropInRequest.getShouldCollectDeviceData());
+        assertEquals("10", dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPrice());
+        assertEquals("USD", dropInRequest.getGooglePayRequest().getTransactionInfo().getCurrencyCode());
+        assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPriceStatus());
+        assertTrue(dropInRequest.getGooglePayRequest().isEmailRequired());
 
         PayPalCheckoutRequest checkoutRequest = (PayPalCheckoutRequest) dropInRequest.getPayPalRequest();
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertFalse(dropInRequest.isGooglePaymentEnabled());
-        assertFalse(parceledDropInRequest.isPayPalEnabled());
-        assertFalse(parceledDropInRequest.isVenmoEnabled());
-        assertFalse(parceledDropInRequest.isCardEnabled());
-        assertTrue(parceledDropInRequest.shouldRequestThreeDSecureVerification());
+        assertFalse(dropInRequest.getGooglePayDisabled());
+        assertFalse(parceledDropInRequest.getPayPalDisabled());
+        assertFalse(parceledDropInRequest.getVenmoDisabled());
+        assertFalse(parceledDropInRequest.getCardDisabled());
+        assertTrue(parceledDropInRequest.getShouldRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());
         assertEquals("10.00", dropInRequest.getThreeDSecureRequest().getAmount());
@@ -228,13 +228,13 @@ public class DropInRequestUnitTest {
         assertEquals("US", dropInRequest.getThreeDSecureRequest().getBillingAddress().getCountryCodeAlpha2());
         assertEquals("3125557890", dropInRequest.getThreeDSecureRequest().getBillingAddress().getPhoneNumber());
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
-        assertTrue(parceledDropInRequest.shouldMaskCardNumber());
-        assertTrue(parceledDropInRequest.shouldMaskSecurityCode());
+        assertTrue(parceledDropInRequest.getShouldMaskCardNumber());
+        assertTrue(parceledDropInRequest.getShouldMaskSecurityCode());
         assertTrue(parceledDropInRequest.getEnableVaultManager());
         assertTrue(parceledDropInRequest.getVaultCardDefaultValue());
         assertTrue(parceledDropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, parceledDropInRequest.getCardholderNameStatus());
-        assertTrue(parceledDropInRequest.shouldVaultVenmo());
+        assertTrue(parceledDropInRequest.getVaultVenmoDefaultValue());
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
-import static com.braintreepayments.api.TestTokenizationKey.TOKENIZATION_KEY;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
@@ -57,28 +56,24 @@ public class DropInRequestUnitTest {
         additionalInformation.setShippingMethodIndicator("GEN");
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
-        Intent intent = new DropInRequest()
-                .collectDeviceData(true)
-                .googlePaymentRequest(googlePayRequest)
-                .disableGooglePayment()
-                .paypalRequest(paypalRequest)
-                .disablePayPal()
-                .disableVenmo()
-                .disableCard()
-                .requestThreeDSecureVerification(true)
-                .threeDSecureRequest(threeDSecureRequest)
-                .maskCardNumber(true)
-                .maskSecurityCode(true)
-                .vaultManager(true)
-                .allowVaultCardOverride(true)
-                .vaultCard(true)
-                .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .vaultVenmo(true)
-                .getIntent(RuntimeEnvironment.application);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setGooglePayRequest(googlePayRequest);
+        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setPayPalRequest(paypalRequest);
+        dropInRequest.setDisablePayPal(true);
+        dropInRequest.setDisableVenmo(true);
+        dropInRequest.setDisableCard(true);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setEnableVaultManager(true);
+        dropInRequest.setAllowVaultCardOverride(true);
+        dropInRequest.setVaultCardDefaultValue(true);
+        dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
+        dropInRequest.setVaultVenmoDefaultValue(true);
 
-        DropInRequest dropInRequest = intent.getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
-
-        assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
         assertTrue(dropInRequest.shouldCollectDeviceData());
         assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
         assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
@@ -111,9 +106,9 @@ public class DropInRequestUnitTest {
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
         assertTrue(dropInRequest.shouldMaskCardNumber());
         assertTrue(dropInRequest.shouldMaskSecurityCode());
-        assertTrue(dropInRequest.isVaultManagerEnabled());
-        assertTrue(dropInRequest.getDefaultVaultSetting());
-        assertTrue(dropInRequest.isSaveCardCheckBoxShown());
+        assertTrue(dropInRequest.getEnableVaultManager());
+        assertTrue(dropInRequest.getVaultCardDefaultValue());
+        assertTrue(dropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, dropInRequest.getCardholderNameStatus());
         assertTrue(dropInRequest.shouldVaultVenmo());
     }
@@ -137,9 +132,9 @@ public class DropInRequestUnitTest {
         assertNull(dropInRequest.getThreeDSecureRequest());
         assertFalse(dropInRequest.shouldMaskCardNumber());
         assertFalse(dropInRequest.shouldMaskSecurityCode());
-        assertFalse(dropInRequest.isVaultManagerEnabled());
-        assertFalse(dropInRequest.isSaveCardCheckBoxShown());
-        assertTrue(dropInRequest.getDefaultVaultSetting());
+        assertFalse(dropInRequest.getEnableVaultManager());
+        assertFalse(dropInRequest.getAllowVaultCardOverride());
+        assertTrue(dropInRequest.getVaultCardDefaultValue());
         assertFalse(dropInRequest.shouldVaultVenmo());
         assertEquals(CardForm.FIELD_DISABLED, dropInRequest.getCardholderNameStatus());
     }
@@ -180,23 +175,23 @@ public class DropInRequestUnitTest {
         additionalInformation.setShippingMethodIndicator("GEN");
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
-        DropInRequest dropInRequest = new DropInRequest()
-                .collectDeviceData(true)
-                .googlePaymentRequest(googlePayRequest)
-                .disableGooglePayment()
-                .paypalRequest(paypalRequest)
-                .disablePayPal()
-                .disableVenmo()
-                .disableCard()
-                .requestThreeDSecureVerification(true)
-                .threeDSecureRequest(threeDSecureRequest)
-                .maskCardNumber(true)
-                .maskSecurityCode(true)
-                .vaultManager(true)
-                .vaultCard(true)
-                .allowVaultCardOverride(true)
-                .cardholderNameStatus(CardForm.FIELD_OPTIONAL)
-                .vaultVenmo(true);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setGooglePayRequest(googlePayRequest);
+        dropInRequest.setDisableGooglePay(true);
+        dropInRequest.setPayPalRequest(paypalRequest);
+        dropInRequest.setDisablePayPal(true);
+        dropInRequest.setDisableVenmo(true);
+        dropInRequest.setDisableCard(true);
+        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setEnableVaultManager(true);
+        dropInRequest.setAllowVaultCardOverride(true);
+        dropInRequest.setVaultCardDefaultValue(true);
+        dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
+        dropInRequest.setVaultVenmoDefaultValue(true);
 
         Parcel parcel = Parcel.obtain();
         dropInRequest.writeToParcel(parcel, 0);
@@ -235,17 +230,17 @@ public class DropInRequestUnitTest {
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
         assertTrue(parceledDropInRequest.shouldMaskCardNumber());
         assertTrue(parceledDropInRequest.shouldMaskSecurityCode());
-        assertTrue(parceledDropInRequest.isVaultManagerEnabled());
-        assertTrue(parceledDropInRequest.getDefaultVaultSetting());
-        assertTrue(parceledDropInRequest.isSaveCardCheckBoxShown());
+        assertTrue(parceledDropInRequest.getEnableVaultManager());
+        assertTrue(parceledDropInRequest.getVaultCardDefaultValue());
+        assertTrue(parceledDropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, parceledDropInRequest.getCardholderNameStatus());
         assertTrue(parceledDropInRequest.shouldVaultVenmo());
     }
 
     @Test
     public void getCardholderNameStatus_includesCardHolderNameStatus() {
-        DropInRequest dropInRequest = new DropInRequest()
-                .cardholderNameStatus(CardForm.FIELD_REQUIRED);
+        DropInRequest dropInRequest = new DropInRequest();
+        dropInRequest.setCardholderNameStatus(CardForm.FIELD_REQUIRED);
 
         assertEquals(CardForm.FIELD_REQUIRED, dropInRequest.getCardholderNameStatus());
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -59,7 +59,6 @@ public class DropInRequestUnitTest {
 
         Intent intent = new DropInRequest()
                 .collectDeviceData(true)
-                .amount("1.00")
                 .googlePaymentRequest(googlePayRequest)
                 .disableGooglePayment()
                 .paypalRequest(paypalRequest)
@@ -81,7 +80,6 @@ public class DropInRequestUnitTest {
 
         assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
         assertTrue(dropInRequest.shouldCollectDeviceData());
-        assertEquals("1.00", dropInRequest.getAmount());
         assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
         assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPriceStatus());
@@ -130,7 +128,6 @@ public class DropInRequestUnitTest {
         assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
         assertNull(dropInRequest.getAuthorization());
         assertFalse(dropInRequest.shouldCollectDeviceData());
-        assertNull(dropInRequest.getAmount());
         assertTrue(dropInRequest.isGooglePaymentEnabled());
         assertNull(dropInRequest.getPayPalRequest());
         assertTrue(dropInRequest.isPayPalEnabled());
@@ -185,7 +182,6 @@ public class DropInRequestUnitTest {
 
         DropInRequest dropInRequest = new DropInRequest()
                 .collectDeviceData(true)
-                .amount("1.00")
                 .googlePaymentRequest(googlePayRequest)
                 .disableGooglePayment()
                 .paypalRequest(paypalRequest)
@@ -208,7 +204,6 @@ public class DropInRequestUnitTest {
         DropInRequest parceledDropInRequest = DropInRequest.CREATOR.createFromParcel(parcel);
 
         assertTrue(parceledDropInRequest.shouldCollectDeviceData());
-        assertEquals("1.00", parceledDropInRequest.getAmount());
         assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
         assertEquals("USD", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPriceStatus());

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -53,38 +53,38 @@ public class DropInRequestUnitTest {
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
         dropInRequest.setGooglePayRequest(googlePayRequest);
         dropInRequest.setGooglePayDisabled(true);
         dropInRequest.setPayPalRequest(paypalRequest);
         dropInRequest.setPayPalDisabled(true);
         dropInRequest.setVenmoDisabled(true);
         dropInRequest.setCardDisabled(true);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldMaskCardNumber(true);
-        dropInRequest.setShouldMaskSecurityCode(true);
-        dropInRequest.setEnableVaultManager(true);
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setVaultManagerEnabled(true);
         dropInRequest.setAllowVaultCardOverride(true);
         dropInRequest.setVaultCardDefaultValue(true);
         dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
         dropInRequest.setVaultVenmoDefaultValue(true);
 
-        assertTrue(dropInRequest.getShouldCollectDeviceData());
+        assertTrue(dropInRequest.getCollectDeviceData());
         assertEquals("10", dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPrice());
         assertEquals("USD", dropInRequest.getGooglePayRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPriceStatus());
         assertTrue(dropInRequest.getGooglePayRequest().isEmailRequired());
-        assertTrue(dropInRequest.getGooglePayDisabled());
+        assertTrue(dropInRequest.isGooglePayDisabled());
 
         PayPalCheckoutRequest checkoutRequest = (PayPalCheckoutRequest) dropInRequest.getPayPalRequest();
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertTrue(dropInRequest.getPayPalDisabled());
-        assertTrue(dropInRequest.getVenmoDisabled());
-        assertTrue(dropInRequest.getCardDisabled());
-        assertTrue(dropInRequest.getShouldRequestThreeDSecureVerification());
+        assertTrue(dropInRequest.isPayPalDisabled());
+        assertTrue(dropInRequest.isVenmoDisabled());
+        assertTrue(dropInRequest.isCardDisabled());
+        assertTrue(dropInRequest.getRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());
         assertEquals("10.00", dropInRequest.getThreeDSecureRequest().getAmount());
@@ -100,9 +100,9 @@ public class DropInRequestUnitTest {
         assertEquals("US", dropInRequest.getThreeDSecureRequest().getBillingAddress().getCountryCodeAlpha2());
         assertEquals("3125557890", dropInRequest.getThreeDSecureRequest().getBillingAddress().getPhoneNumber());
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
-        assertTrue(dropInRequest.getShouldMaskCardNumber());
-        assertTrue(dropInRequest.getShouldMaskSecurityCode());
-        assertTrue(dropInRequest.getEnableVaultManager());
+        assertTrue(dropInRequest.getMaskCardNumber());
+        assertTrue(dropInRequest.getMaskSecurityCode());
+        assertTrue(dropInRequest.isVaultManagerEnabled());
         assertTrue(dropInRequest.getVaultCardDefaultValue());
         assertTrue(dropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, dropInRequest.getCardholderNameStatus());
@@ -146,18 +146,18 @@ public class DropInRequestUnitTest {
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
         DropInRequest dropInRequest = new DropInRequest();
-        dropInRequest.setShouldCollectDeviceData(true);
+        dropInRequest.setCollectDeviceData(true);
         dropInRequest.setGooglePayRequest(googlePayRequest);
         dropInRequest.setGooglePayDisabled(true);
         dropInRequest.setPayPalRequest(paypalRequest);
         dropInRequest.setPayPalDisabled(true);
         dropInRequest.setVenmoDisabled(true);
         dropInRequest.setCardDisabled(true);
-        dropInRequest.setShouldRequestThreeDSecureVerification(true);
+        dropInRequest.setRequestThreeDSecureVerification(true);
         dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-        dropInRequest.setShouldMaskCardNumber(true);
-        dropInRequest.setShouldMaskSecurityCode(true);
-        dropInRequest.setEnableVaultManager(true);
+        dropInRequest.setMaskCardNumber(true);
+        dropInRequest.setMaskSecurityCode(true);
+        dropInRequest.setVaultManagerEnabled(true);
         dropInRequest.setAllowVaultCardOverride(true);
         dropInRequest.setVaultCardDefaultValue(true);
         dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
@@ -168,7 +168,7 @@ public class DropInRequestUnitTest {
         parcel.setDataPosition(0);
         DropInRequest parceledDropInRequest = DropInRequest.CREATOR.createFromParcel(parcel);
 
-        assertTrue(parceledDropInRequest.getShouldCollectDeviceData());
+        assertTrue(parceledDropInRequest.getCollectDeviceData());
         assertEquals("10", dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPrice());
         assertEquals("USD", dropInRequest.getGooglePayRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPriceStatus());
@@ -178,11 +178,11 @@ public class DropInRequestUnitTest {
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertTrue(dropInRequest.getGooglePayDisabled());
-        assertTrue(parceledDropInRequest.getPayPalDisabled());
-        assertTrue(parceledDropInRequest.getVenmoDisabled());
-        assertTrue(parceledDropInRequest.getCardDisabled());
-        assertTrue(parceledDropInRequest.getShouldRequestThreeDSecureVerification());
+        assertTrue(dropInRequest.isGooglePayDisabled());
+        assertTrue(parceledDropInRequest.isPayPalDisabled());
+        assertTrue(parceledDropInRequest.isVenmoDisabled());
+        assertTrue(parceledDropInRequest.isCardDisabled());
+        assertTrue(parceledDropInRequest.getRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());
         assertEquals("10.00", dropInRequest.getThreeDSecureRequest().getAmount());
@@ -198,9 +198,9 @@ public class DropInRequestUnitTest {
         assertEquals("US", dropInRequest.getThreeDSecureRequest().getBillingAddress().getCountryCodeAlpha2());
         assertEquals("3125557890", dropInRequest.getThreeDSecureRequest().getBillingAddress().getPhoneNumber());
         assertEquals("GEN", dropInRequest.getThreeDSecureRequest().getAdditionalInformation().getShippingMethodIndicator());
-        assertTrue(parceledDropInRequest.getShouldMaskCardNumber());
-        assertTrue(parceledDropInRequest.getShouldMaskSecurityCode());
-        assertTrue(parceledDropInRequest.getEnableVaultManager());
+        assertTrue(parceledDropInRequest.getMaskCardNumber());
+        assertTrue(parceledDropInRequest.getMaskSecurityCode());
+        assertTrue(parceledDropInRequest.isVaultManagerEnabled());
         assertTrue(parceledDropInRequest.getVaultCardDefaultValue());
         assertTrue(parceledDropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, parceledDropInRequest.getCardholderNameStatus());

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -58,7 +58,6 @@ public class DropInRequestUnitTest {
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
         Intent intent = new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .collectDeviceData(true)
                 .amount("1.00")
                 .googlePaymentRequest(googlePayRequest)
@@ -81,7 +80,6 @@ public class DropInRequestUnitTest {
         DropInRequest dropInRequest = intent.getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
 
         assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
-        assertEquals(TOKENIZATION_KEY, dropInRequest.getAuthorization());
         assertTrue(dropInRequest.shouldCollectDeviceData());
         assertEquals("1.00", dropInRequest.getAmount());
         assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
@@ -186,7 +184,6 @@ public class DropInRequestUnitTest {
         threeDSecureRequest.setAdditionalInformation(additionalInformation);
 
         DropInRequest dropInRequest = new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY)
                 .collectDeviceData(true)
                 .amount("1.00")
                 .googlePaymentRequest(googlePayRequest)
@@ -210,7 +207,6 @@ public class DropInRequestUnitTest {
         parcel.setDataPosition(0);
         DropInRequest parceledDropInRequest = DropInRequest.CREATOR.createFromParcel(parcel);
 
-        assertEquals(TOKENIZATION_KEY, parceledDropInRequest.getAuthorization());
         assertTrue(parceledDropInRequest.shouldCollectDeviceData());
         assertEquals("1.00", parceledDropInRequest.getAmount());
         assertEquals("10", dropInRequest.getGooglePaymentRequest().getTransactionInfo().getTotalPrice());
@@ -249,22 +245,6 @@ public class DropInRequestUnitTest {
         assertTrue(parceledDropInRequest.isSaveCardCheckBoxShown());
         assertEquals(CardForm.FIELD_OPTIONAL, parceledDropInRequest.getCardholderNameStatus());
         assertTrue(parceledDropInRequest.shouldVaultVenmo());
-    }
-
-    @Test
-    public void getIntent_includesClientToken() {
-        DropInRequest dropInRequest = new DropInRequest()
-                .clientToken(Fixtures.CLIENT_TOKEN);
-
-        assertEquals(Fixtures.CLIENT_TOKEN, dropInRequest.getAuthorization());
-    }
-
-    @Test
-    public void getIntent_includesTokenizationKey() {
-        DropInRequest dropInRequest = new DropInRequest()
-                .tokenizationKey(TOKENIZATION_KEY);
-
-        assertEquals(TOKENIZATION_KEY, dropInRequest.getAuthorization());
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -1,6 +1,5 @@
 package com.braintreepayments.api;
 
-import android.content.Intent;
 import android.os.Parcel;
 
 import com.braintreepayments.cardform.view.CardForm;
@@ -10,11 +9,8 @@ import com.google.android.gms.wallet.WalletConstants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -79,15 +75,15 @@ public class DropInRequestUnitTest {
         assertEquals("USD", dropInRequest.getGooglePayRequest().getTransactionInfo().getCurrencyCode());
         assertEquals(WalletConstants.TOTAL_PRICE_STATUS_FINAL, dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPriceStatus());
         assertTrue(dropInRequest.getGooglePayRequest().isEmailRequired());
-        assertFalse(dropInRequest.getGooglePayDisabled());
+        assertTrue(dropInRequest.getGooglePayDisabled());
 
         PayPalCheckoutRequest checkoutRequest = (PayPalCheckoutRequest) dropInRequest.getPayPalRequest();
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertFalse(dropInRequest.getPayPalDisabled());
-        assertFalse(dropInRequest.getVenmoDisabled());
-        assertFalse(dropInRequest.getCardDisabled());
+        assertTrue(dropInRequest.getPayPalDisabled());
+        assertTrue(dropInRequest.getVenmoDisabled());
+        assertTrue(dropInRequest.getCardDisabled());
         assertTrue(dropInRequest.getShouldRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());
@@ -111,32 +107,6 @@ public class DropInRequestUnitTest {
         assertTrue(dropInRequest.getAllowVaultCardOverride());
         assertEquals(CardForm.FIELD_OPTIONAL, dropInRequest.getCardholderNameStatus());
         assertTrue(dropInRequest.getVaultVenmoDefaultValue());
-    }
-
-    @Test
-    public void hasCorrectDefaults() {
-        Intent intent = new DropInRequest()
-                .getIntent(RuntimeEnvironment.application);
-
-        DropInRequest dropInRequest = intent.getParcelableExtra(DropInRequest.EXTRA_CHECKOUT_REQUEST);
-
-        assertEquals(DropInActivity.class.getName(), intent.getComponent().getClassName());
-        assertNull(dropInRequest.getAuthorization());
-        assertFalse(dropInRequest.getShouldCollectDeviceData());
-        assertTrue(dropInRequest.getGooglePayDisabled());
-        assertNull(dropInRequest.getPayPalRequest());
-        assertTrue(dropInRequest.getPayPalDisabled());
-        assertTrue(dropInRequest.getVenmoDisabled());
-        assertTrue(dropInRequest.getCardDisabled());
-        assertFalse(dropInRequest.getShouldRequestThreeDSecureVerification());
-        assertNull(dropInRequest.getThreeDSecureRequest());
-        assertFalse(dropInRequest.getShouldMaskCardNumber());
-        assertFalse(dropInRequest.getShouldMaskSecurityCode());
-        assertFalse(dropInRequest.getEnableVaultManager());
-        assertFalse(dropInRequest.getAllowVaultCardOverride());
-        assertTrue(dropInRequest.getVaultCardDefaultValue());
-        assertFalse(dropInRequest.getVaultVenmoDefaultValue());
-        assertEquals(CardForm.FIELD_DISABLED, dropInRequest.getCardholderNameStatus());
     }
 
     @Test
@@ -208,10 +178,10 @@ public class DropInRequestUnitTest {
         assertEquals("10.00", checkoutRequest.getAmount());
         assertEquals("USD", checkoutRequest.getCurrencyCode());
 
-        assertFalse(dropInRequest.getGooglePayDisabled());
-        assertFalse(parceledDropInRequest.getPayPalDisabled());
-        assertFalse(parceledDropInRequest.getVenmoDisabled());
-        assertFalse(parceledDropInRequest.getCardDisabled());
+        assertTrue(dropInRequest.getGooglePayDisabled());
+        assertTrue(parceledDropInRequest.getPayPalDisabled());
+        assertTrue(parceledDropInRequest.getVenmoDisabled());
+        assertTrue(parceledDropInRequest.getCardDisabled());
         assertTrue(parceledDropInRequest.getShouldRequestThreeDSecureVerification());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -1,0 +1,7 @@
+# Braintree Android Drop-In v6 Migration Guide
+
+See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your Braintree Drop-In integration from `v5` to `v6`.
+
+`v6` of the Drop-In SDK is compatible with `v4` of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
+
+_Documentation for v6 will be published to https://developer.paypal.com/braintree/docs once it is available for general release._

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -155,7 +155,7 @@ dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE)
 
 ## Handle Drop-In Result
 
-Handle the result from Drop-In in `onActivityResult` as in v5. 
+You should handle the `<TYPE>` in `onActivityResult`, the same was as you did in your v5 integration.
 
 Changes:
 - The key for accessing an error from the Activity result has changed from `DropInActivity.EXTRA_ERROR` to `DropInResult.EXTRA_ERROR`.

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -11,6 +11,7 @@ _Documentation for v6 will be published to https://developer.paypal.com/braintre
 1. [Gradle](#gradle)
 1. [Builder Pattern](#builder-pattern)
 1. [DropInRequest](#dropinrequest)
+1. [DropInClient](#dropinclient)
 1. [Authorization](#authorization)
 1. [Launch Drop-In](#launch-drop-in)
 1. [Handle Drop-In Result](#handle-drop-in-result)

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -127,14 +127,31 @@ The full list of changed parameters is below:
 1. `vaultCard` -> `vaultCardDefaultValue`
 1. `vaultVenmo` -> `vaultVenmoDefaultValue`
 
+## DropInClient
+
+`DropInClient` has been added in `v6` and replaces the use of an `Intent` to start Drop-in.
+See the sections below for code snippets to instantiate a `DropInClient` with authorization, and launch Drop-in.
+
 ## Authorization
 
 The `clientToken`, `tokenizationKey`, and `authorization` fields have been removed from `DropInRequest`. 
 In v6, authorization should be included when instantiating a `DropInClient` instead.
 
+Java:
+```java
+DropInRequest dropInRequest = new DropInRequest();
+DropInClient dropInClient = new DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest);
+```
+
+Kotlin:
+```kotlin
+val dropInRequest = DropInRequest()
+val dropInClient = DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest)
+```
+
 ## Launch Drop-In 
 
-`DropInClient` has been added in v6 and is responsible for launching `DropInActivity`. 
+`DropInClient` is responsible for launching `DropInActivity`. 
 To launch Drop-In, instantiate a `DropInClient` and call `DropInClient#launchDropInForResult`:
 
 Java:

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -10,6 +10,7 @@ _Documentation for v6 will be published to https://developer.paypal.com/braintre
 
 1. [Gradle](#gradle)
 1. [Builder Pattern](#builder-pattern)
+1. [DropInRequest](#dropinrequest)
 1. [Authorization](#authorization)
 1. [Launch Drop-In](#launch-drop-in)
 1. [Handle Drop-In Result](#handle-drop-in-result)
@@ -64,9 +65,75 @@ request.maskCardNumber = true
 
 See the [Braintree Android v4 Migration Guide](https://github.com/braintree/braintree_android/blob/master/v4_MIGRATION_GUIDE.md) for changes to request objects for Google Pay, Venmo, PayPal, and 3DS. 
 
+## DropInRequest
+
+The getters and setters on `DropInRequest` have been renamed with a consistent get/set pattern to allow for Kotlin synthesized properties. 
+See the examples below for a full list of optional parameters:
+
+Java:
+```java
+    DropInRequest dropInRequest = new DropInRequest();
+    dropInRequest.setShouldCollectDeviceData(true);
+    dropInRequest.setGooglePayRequest(googlePayRequest);
+    dropInRequest.setGooglePayDisabled(true);
+    dropInRequest.setPayPalRequest(paypalRequest);
+    dropInRequest.setPayPalDisabled(true);
+    dropInRequest.setVenmoDisabled(true);
+    dropInRequest.setCardDisabled(true);
+    dropInRequest.setShouldRequestThreeDSecureVerification(true);
+    dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
+    dropInRequest.setShouldMaskCardNumber(true);
+    dropInRequest.setShouldMaskSecurityCode(true);
+    dropInRequest.setEnableVaultManager(true);
+    dropInRequest.setAllowVaultCardOverride(true);
+    dropInRequest.setVaultCardDefaultValue(true);
+    dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
+    dropInRequest.setVaultVenmoDefaultValue(true);
+```
+
+Kotlin:
+```kotlin
+    val dropInRequest = DropInRequest()
+    dropInRequest.shouldCollectDeviceData = true
+    dropInRequest.googlePayRequest = googlePayRequest
+    dropInRequest.googlePayDisabled = true
+    dropInRequest.payPalRequest = paypalRequest
+    dropInRequest.payPalDisabled = true
+    dropInRequest.venmoDisabled = true
+    dropInRequest.cardDisabled = true
+    dropInRequest.shouldRequestThreeDSecureVerification = true
+    dropInRequest.threeDSecureRequest = threeDSecureRequest
+    dropInRequest.shouldMaskCardNumber = true
+    dropInRequest.shouldMaskSecurityCode = true
+    dropInRequest.enableVaultManager = true
+    dropInRequest.allowVaultCardOverride = true
+    dropInRequest.vaultCardDefaultValue = true
+    dropInRequest.cardholderNameStatus = FIELD_OPTIONAL
+    dropInRequest.vaultVenmoDefaultValue = true
+```
+
+The full list of changed parameters is below:
+1. `clientTokent` -> removed
+1. `tokenizationKey` -> removed
+1. `amount` -> removed
+1. `intent` -> removed
+1. `collectDeviceData` -> `shouldCollectDeviceData`
+1. `googlePaymentRequest` -> `googlePayRequest`
+1. `disableGooglePayment` -> `googlePayDisabled`
+1. `paypalRequest` -> `payPalRequest`
+1. `disablePayPal` -> `payPalDisabled`
+1. `disableVenmo` -> `venmoDisabled`
+1. `disableCard` -> `cardDisabled`
+1. `requestThreeDSecureVerification` -> `shouldRequestThreeDSecureVerification`
+1. `maskCardNumber` -> `shouldMaskCardNumber`
+1. `maskSecurityCode` -> `shouldMaskSecurityCode`
+1. `vaultManager` -> `enableVaultManager`
+1. `vaultCard` -> `vaultCardDefaultValue`
+1. `vaultVenmo` -> `vaultVenmoDefaultValue`
+
 ## Authorization
 
-The `clientToken` and `tokenizationKey` parameters have been removed from `DropInRequest`. 
+The `clientToken`, `tokenizationKey`, and `authorization` fields have been removed from `DropInRequest`. 
 In v6, authorization should be included when instantiating a `DropInClient` instead.
 
 ## Launch Drop-In 

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -10,7 +10,9 @@ _Documentation for v6 will be published to https://developer.paypal.com/braintre
 
 1. [Gradle](#gradle)
 1. [Builder Pattern](#builder-pattern)
-1. [Launching Drop-In](#launching-drop-in)
+1. [Launch Drop-In](#launch-drop-in)
+1. [Handle Drop-In Result](#handle-drop-in-result)
+1. [Fetch Last Used Payment Method](#fetch-last-used-payment-method)
 
 ## Gradle
 
@@ -61,7 +63,7 @@ request.maskCardNumber = true
 
 See the [Braintree Android v4 Migration Guide](https://github.com/braintree/braintree_android/blob/master/v4_MIGRATION_GUIDE.md) for changes to request objects for Google Pay, Venmo, PayPal, and 3DS. 
 
-## Launching Drop-In 
+## Launch Drop-In 
 
 `DropInClient` has been added in v6 and is responsible for launching `DropInActivity`. 
 To launch Drop-In, instantiate a `DropInClient` and call `DropInClient#launchDropInForResult`:
@@ -76,4 +78,68 @@ Kotlin:
 ```kotlin
 val dropInClient = DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest)
 dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE)
+```
+
+## Handle Drop-In Result
+
+Handle the result from Drop-In in `onActivityResult` as in v5. 
+The key for accessing an error from the Activity result has moved from `DropInActivity.EXTRA_ERROR` to `DropInResult.EXTRA_ERROR`.
+The method for accessing the `String` payment method nonce from `DropInResult` has been updated from `PaymentMethodNonce#getNonce` to `PaymentMethodNonce#getString`. 
+
+
+Java:
+```java
+@Override
+public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    if (requestCode == DROP_IN_REQUEST_CODE) {
+        if (resultCode == RESULT_OK) {
+            DropInResult result = data.getParcelableExtra(DropInResult.EXTRA_DROP_IN_RESULT);
+            String paymentMethodNonce = result.getPaymentMethodNonce().getString();
+            // send paymentMethodNonce to your server
+        } else if (resultCode == RESULT_CANCELED) {
+            // canceled
+        } else {
+            // an error occurred, checked the returned exception
+            Exception exception = (Exception) data.getSerializableExtra(DropInActivity.EXTRA_ERROR);
+        }
+    }
+}
+```
+
+Kotlin:
+```kotlin
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == DROP_IN_REQUEST_CODE) {
+            if (resultCode == RESULT_OK) {
+                val result: DropInResult? = data?.getParcelableExtra(DropInResult.EXTRA_DROP_IN_RESULT)
+                val paymentMethodNonce = result?.paymentMethodNonce?.string
+                // use the result to update your UI and send the payment method nonce to your server
+            } else if (resultCode == RESULT_CANCELED) {
+                // the user canceled
+            } else {
+                // handle errors here, an exception may be available in
+                val error: Exception? = data?.getSerializableExtra(DropInResult.EXTRA_ERROR) as Exception?
+            }
+        }
+    }
+```
+
+## Fetch Last Used Payment Method
+
+Fetching a user's existing payment method has moved from `DropInResult#fetchDropInResult` to `DropInClient#fetchMostRecentPaymentMethod`. 
+Note that a payment method will only be returned when using a client token created with a customer_id.
+
+Java:
+```java
+    DropInClient dropInClient = new DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest);
+    dropInClient.fetchMostRecentPaymentMethod(this, new FetchMostRecentPaymentMethodCallback() {
+        @Override
+        public void onResult(DropInResult dropInResult, Exception error) {
+            // handle result
+        }
+    });
 ```

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -73,7 +73,7 @@ See the examples below for a full list of optional parameters:
 Java:
 ```java
     DropInRequest dropInRequest = new DropInRequest();
-    dropInRequest.setShouldCollectDeviceData(true);
+    dropInRequest.setCollectDeviceData(true);
     dropInRequest.setGooglePayRequest(googlePayRequest);
     dropInRequest.setGooglePayDisabled(true);
     dropInRequest.setPayPalRequest(paypalRequest);
@@ -94,7 +94,7 @@ Java:
 Kotlin:
 ```kotlin
     val dropInRequest = DropInRequest()
-    dropInRequest.shouldCollectDeviceData = true
+    dropInRequest.collectDeviceData = true
     dropInRequest.googlePayRequest = googlePayRequest
     dropInRequest.isGooglePayDisabled = true
     dropInRequest.payPalRequest = paypalRequest
@@ -123,7 +123,7 @@ The full list of changed parameters is below:
 1. `disablePayPal` -> `payPalDisabled`
 1. `disableVenmo` -> `venmoDisabled`
 1. `disableCard` -> `cardDisabled`
-1. `vaultManager` -> `enableVaultManager`
+1. `vaultManager` -> `vaultManagerEnabled`
 1. `vaultCard` -> `vaultCardDefaultValue`
 1. `vaultVenmo` -> `vaultVenmoDefaultValue`
 

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -135,11 +135,19 @@ Note that a payment method will only be returned when using a client token creat
 
 Java:
 ```java
-    DropInClient dropInClient = new DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest);
+    DropInClient dropInClient = new DropInClient(this, "CLIENT_TOKEN_WITH_CUSTOMER_ID", dropInRequest);
     dropInClient.fetchMostRecentPaymentMethod(this, new FetchMostRecentPaymentMethodCallback() {
         @Override
         public void onResult(DropInResult dropInResult, Exception error) {
             // handle result
         }
     });
+```
+
+Kotlin:
+```kotlin
+    val dropInClient = DropInClient(this, "CLIENT_TOKEN_WITH_CUSTOMER_ID", dropInRequest)
+    dropInClient.fetchMostRecentPaymentMethod(this) { dropInResult, error ->
+        // handle result
+    }
 ```

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -155,7 +155,7 @@ dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE)
 
 ## Handle Drop-In Result
 
-You should handle the `<TYPE>` in `onActivityResult`, the same was as you did in your v5 integration.
+You should handle the result in `onActivityResult`, the same way as you did in your v5 integration.
 
 Changes:
 - The key for accessing an error from the Activity result has changed from `DropInActivity.EXTRA_ERROR` to `DropInResult.EXTRA_ERROR`.

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -1,8 +1,8 @@
 # Braintree Android Drop-In v6 Migration Guide
 
-See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your Braintree Drop-In integration from `v5` to `v6`.
+See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your Braintree Drop-In integration from v5 to v6.
 
-`v6` of the Drop-In SDK is compatible with `v4` of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
+v6 of the Drop-In SDK is compatible with v4 of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
 
 _Documentation for v6 will be published to https://developer.paypal.com/braintree/docs once it is available for general release._
 
@@ -19,6 +19,22 @@ Add the dependency in your `build.gradle`:
 ```groovy
 dependencies {
   implementation 'com.braintreepayments.api:drop-in:6.0.0'
+}
+```
+
+The credentials for accessing the Cardinal Mobile SDK have changed.
+
+Update the credentials in your top-level build.gradle to the following:
+
+```groovy
+repositories {
+    maven {
+        url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
+        credentials {
+            username 'braintree_team_sdk'
+            password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
+        }
+    }
 }
 ```
 
@@ -47,10 +63,17 @@ See the [Braintree Android v4 Migration Guide](https://github.com/braintree/brai
 
 ## Launching Drop-In 
 
-`DropInClient` has been added in `v6` and is responsible for launching `DropInActivity`. 
-To launch Drop-In:
+`DropInClient` has been added in v6 and is responsible for launching `DropInActivity`. 
+To launch Drop-In, instantiate a `DropInClient` and call `DropInClient#launchDropInForResult`:
 
+Java:
 ```java
 DropInClient dropInClient = new DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest);
 dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE);
+```
+
+Kotlin:
+```kotlin
+val dropInClient = DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest)
+dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE)
 ```

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -80,11 +80,11 @@ Java:
     dropInRequest.setPayPalDisabled(true);
     dropInRequest.setVenmoDisabled(true);
     dropInRequest.setCardDisabled(true);
-    dropInRequest.setShouldRequestThreeDSecureVerification(true);
+    dropInRequest.setRequestThreeDSecureVerification(true);
     dropInRequest.setThreeDSecureRequest(threeDSecureRequest);
-    dropInRequest.setShouldMaskCardNumber(true);
-    dropInRequest.setShouldMaskSecurityCode(true);
-    dropInRequest.setEnableVaultManager(true);
+    dropInRequest.setMaskCardNumber(true);
+    dropInRequest.setMaskSecurityCode(true);
+    dropInRequest.setVaultManagerEnabled(true);
     dropInRequest.setAllowVaultCardOverride(true);
     dropInRequest.setVaultCardDefaultValue(true);
     dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
@@ -96,16 +96,16 @@ Kotlin:
     val dropInRequest = DropInRequest()
     dropInRequest.shouldCollectDeviceData = true
     dropInRequest.googlePayRequest = googlePayRequest
-    dropInRequest.googlePayDisabled = true
+    dropInRequest.isGooglePayDisabled = true
     dropInRequest.payPalRequest = paypalRequest
-    dropInRequest.payPalDisabled = true
-    dropInRequest.venmoDisabled = true
-    dropInRequest.cardDisabled = true
-    dropInRequest.shouldRequestThreeDSecureVerification = true
+    dropInRequest.isPayPalDisabled = true
+    dropInRequest.isVenmoDisabled = true
+    dropInRequest.isCardDisabled = true
+    dropInRequest.requestThreeDSecureVerification = true
     dropInRequest.threeDSecureRequest = threeDSecureRequest
-    dropInRequest.shouldMaskCardNumber = true
-    dropInRequest.shouldMaskSecurityCode = true
-    dropInRequest.enableVaultManager = true
+    dropInRequest.maskCardNumber = true
+    dropInRequest.maskSecurityCode = true
+    dropInRequest.isVaultManagerEnabled = true
     dropInRequest.allowVaultCardOverride = true
     dropInRequest.vaultCardDefaultValue = true
     dropInRequest.cardholderNameStatus = FIELD_OPTIONAL
@@ -117,16 +117,12 @@ The full list of changed parameters is below:
 1. `tokenizationKey` -> removed
 1. `amount` -> removed
 1. `intent` -> removed
-1. `collectDeviceData` -> `shouldCollectDeviceData`
 1. `googlePaymentRequest` -> `googlePayRequest`
 1. `disableGooglePayment` -> `googlePayDisabled`
 1. `paypalRequest` -> `payPalRequest`
 1. `disablePayPal` -> `payPalDisabled`
 1. `disableVenmo` -> `venmoDisabled`
 1. `disableCard` -> `cardDisabled`
-1. `requestThreeDSecureVerification` -> `shouldRequestThreeDSecureVerification`
-1. `maskCardNumber` -> `shouldMaskCardNumber`
-1. `maskSecurityCode` -> `shouldMaskSecurityCode`
 1. `vaultManager` -> `enableVaultManager`
 1. `vaultCard` -> `vaultCardDefaultValue`
 1. `vaultVenmo` -> `vaultVenmoDefaultValue`

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your Braintree Drop-In integration from v5 to v6.
 
-v6 of the Drop-In SDK is compatible with v4 of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
+v6 of the Drop-In SDK requires v4 of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
 
 _Documentation for v6 will be published to https://developer.paypal.com/braintree/docs once it is available for general release._
 

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -156,8 +156,10 @@ dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE)
 ## Handle Drop-In Result
 
 Handle the result from Drop-In in `onActivityResult` as in v5. 
-The key for accessing an error from the Activity result has moved from `DropInActivity.EXTRA_ERROR` to `DropInResult.EXTRA_ERROR`.
-The method for accessing the `String` payment method nonce from `DropInResult` has been updated from `PaymentMethodNonce#getNonce` to `PaymentMethodNonce#getString`. 
+
+Changes:
+- The key for accessing an error from the Activity result has changed from `DropInActivity.EXTRA_ERROR` to `DropInResult.EXTRA_ERROR`.
+- The method for accessing the `String` payment method nonce from `DropInResult` has been updated from `PaymentMethodNonce#getNonce` to `PaymentMethodNonce#getString`. 
 
 
 Java:

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -10,6 +10,7 @@ _Documentation for v6 will be published to https://developer.paypal.com/braintre
 
 1. [Gradle](#gradle)
 1. [Builder Pattern](#builder-pattern)
+1. [Authorization](#authorization)
 1. [Launch Drop-In](#launch-drop-in)
 1. [Handle Drop-In Result](#handle-drop-in-result)
 1. [Fetch Last Used Payment Method](#fetch-last-used-payment-method)
@@ -62,6 +63,11 @@ request.maskCardNumber = true
 ```
 
 See the [Braintree Android v4 Migration Guide](https://github.com/braintree/braintree_android/blob/master/v4_MIGRATION_GUIDE.md) for changes to request objects for Google Pay, Venmo, PayPal, and 3DS. 
+
+## Authorization
+
+The `clientToken` and `tokenizationKey` parameters have been removed from `DropInRequest`. 
+In v6, authorization should be included when instantiating a `DropInClient` instead.
 
 ## Launch Drop-In 
 

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -47,7 +47,7 @@ repositories {
 The builder pattern has been removed in v6 to allow for consistent object creation across Java and Kotlin. 
 Method chaining has been removed, and setters have been renamed with the `set` prefix.
 
-For example, a `DropInRequest` can now be constructed below:
+For example, a `DropInRequest` can now be constructed as shown below:
 
 Java:
 ```java

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -5,3 +5,52 @@ See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migratio
 `v6` of the Drop-In SDK is compatible with `v4` of the [Braintree Android SDK](https://github.com/braintree/braintree_android).
 
 _Documentation for v6 will be published to https://developer.paypal.com/braintree/docs once it is available for general release._
+
+## Table of Contents
+
+1. [Gradle](#gradle)
+1. [Builder Pattern](#builder-pattern)
+1. [Launching Drop-In](#launching-drop-in)
+
+## Gradle
+
+Add the dependency in your `build.gradle`:
+
+```groovy
+dependencies {
+  implementation 'com.braintreepayments.api:drop-in:6.0.0'
+}
+```
+
+## Builder Pattern
+
+The builder pattern has been removed in v6 to allow for consistent object creation across Java and Kotlin. 
+Method chaining has been removed, and setters have been renamed with the `set` prefix.
+
+For example, a `DropInRequest` can now be constructed below:
+
+Java:
+```java
+DropInRequest request = new DropInRequest();
+request.setCollectDeviceData(true);
+request.setMaskCardNumber(true);
+```
+
+Kotlin:
+```kotlin
+val request = DropInRequest()
+request.collectDeviceData = true
+request.maskCardNumber = true
+```
+
+See the [Braintree Android v4 Migration Guide](https://github.com/braintree/braintree_android/blob/master/v4_MIGRATION_GUIDE.md) for changes to request objects for Google Pay, Venmo, PayPal, and 3DS. 
+
+## Launching Drop-In 
+
+`DropInClient` has been added in `v6` and is responsible for launching `DropInActivity`. 
+To launch Drop-In:
+
+```java
+DropInClient dropInClient = new DropInClient(this, "TOKENIZATION_KEY_OR_CLIENT_TOKEN", dropInRequest);
+dropInClient.launchDropInForResult(this, DROP_IN_REQUEST_CODE);
+```


### PR DESCRIPTION
### Summary of changes

 - Add migration guide for Drop-in v6 and make code changes to align with migration guide code snippets
 - Remove builder pattern from `DropInRequest` to align with other Android Core v4 request objects
 - Update `DropInRequest` getter / setter method names for clarify and to allow for Kotlin synthesized property (getter must match setter for this)
 -   Remove `clientToken`, `tokenizationKey`, and `authorization` from `DropInRequest` in favor of instantiating `DropInClient` with authorization
 - Remove deprecated `amount` and unnecessary `intent` parameter from `DropInRequest`
 - Replace `DropInActivity.EXTRA_ERROR` with `DropInResult.EXTRA_ERROR` to match `DropInResult.EXTRA_DROP_IN_RESULT`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
