### PR TITLE
Fix Demo App Integration Tests

### DIFF
--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/CardholderNameDropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/CardholderNameDropInTest.java
@@ -28,6 +28,7 @@ public class CardholderNameDropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void cardholderName_whenDisabled_isHidden() {
         setCardholderNameStatus(CardForm.FIELD_DISABLED);
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists(20000).waitForEnabled(20000).perform(click());
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(VISA));
@@ -44,6 +45,7 @@ public class CardholderNameDropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void cardholderName_whenRequired_mustBeFilled() {
         setCardholderNameStatus(CardForm.FIELD_REQUIRED);
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists(20000).waitForEnabled(20000).perform(click());
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(VISA));
@@ -64,6 +66,7 @@ public class CardholderNameDropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void cardholderName_whenOptional_isShownButCanRemainEmpty() {
         setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists(20000).waitForEnabled(20000).perform(click());
         onDevice(withText("Credit or Debit Card")).perform(click());
         onDevice(withText("Card Number")).perform(setText(VISA));

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/DropInTest.java
@@ -52,6 +52,7 @@ public class DropInTest extends TestHelper {
 
     @Test(timeout = 60000)
     public void tokenizesACard() {
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(VISA);
@@ -65,6 +66,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void tokenizesACardWithATokenizationKey() {
         useTokenizationKey();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(VISA);
@@ -78,6 +80,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void tokenizesACard_whenClientTokenWithCustomerId_vaults() {
         setUniqueCustomerId();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(VISA);
@@ -89,6 +92,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void performsThreeDSecureVerification() {
         enableThreeDSecure();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(THREE_D_SECURE_VERIFICATON);
@@ -112,6 +116,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void performsThreeDSecure2FrictionlessVerification() {
         enableThreeDSecure();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(THREE_D_SECURE_2_FRICTIONLESS_VERIFICATON);
@@ -127,6 +132,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void performsThreeDSecure2ChallengeVerification() throws IOException {
         enableThreeDSecure();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(THREE_D_SECURE_2_CHALLENGE_VERIFICATON);
@@ -149,6 +155,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void cancelsThreeDSecure2ChallengeVerification() {
         enableThreeDSecure();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         tokenizeCard(THREE_D_SECURE_2_CHALLENGE_VERIFICATON);
@@ -166,6 +173,7 @@ public class DropInTest extends TestHelper {
     @Test
     public void tokenizesUnionPay() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("Credit or Debit Card")).perform(click());
@@ -195,6 +203,7 @@ public class DropInTest extends TestHelper {
     @Test
     public void tokenizesUnionPayWhenEnrollmentIsNotRequired() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("Credit or Debit Card")).perform(click());
@@ -222,6 +231,7 @@ public class DropInTest extends TestHelper {
     @Test
     public void tokenizesUnionPayWhenFirstSMSCodeIsInvalid() {
         setMerchantAccountId(Settings.getUnionPayMerchantAccountId(getTargetContext()));
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("Credit or Debit Card")).perform(click());
@@ -248,6 +258,7 @@ public class DropInTest extends TestHelper {
 
     @Test(timeout = 60000)
     public void tokenizesPayPal() {
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("PayPal")).perform(click());
@@ -262,6 +273,7 @@ public class DropInTest extends TestHelper {
     @Test(timeout = 60000)
     public void tokenizesPayPalWithATokenizationKey() {
         useTokenizationKey();
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("PayPal")).waitForExists().perform(click());
@@ -276,6 +288,7 @@ public class DropInTest extends TestHelper {
     @RequiresDevice
     @Test(timeout = 60000)
     public void tokenizesGooglePay() {
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("Google Pay")).perform(click());
@@ -289,6 +302,7 @@ public class DropInTest extends TestHelper {
 
     @Test(timeout = 60000)
     public void exitsAfterCancelingAddingAPaymentMethod() {
+        launchApp();
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
 
         onDevice(withText("PayPal")).perform(click());
@@ -305,6 +319,7 @@ public class DropInTest extends TestHelper {
     public void deletesPaymentMethod() {
         setUniqueCustomerId();
         enableVaultManager();
+        launchApp();
         setSaveCardCheckBox(true, true);
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
@@ -323,7 +338,7 @@ public class DropInTest extends TestHelper {
         onDevice(withText("Done")).waitForExists().perform(click());
 
         onDevice().pressBack();
-        onDevice(withText("Select Payment Method")).waitForExists();
+        onDevice(withText("Visa")).waitForExists().perform(click());
 
         assertFalse(onDevice(withResourceId("com.braintreepayments.demo:id/bt_payment_method_title")).exists());
     }

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/OptionalVaultingDropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/OptionalVaultingDropInTest.java
@@ -25,6 +25,7 @@ public class OptionalVaultingDropInTest extends TestHelper {
     public void saveCardCheckBox_whenVisibleAndChecked_vaults() {
         setSaveCardCheckBox(true, true);
         setUniqueCustomerId();
+        launchApp();
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);
@@ -39,6 +40,7 @@ public class OptionalVaultingDropInTest extends TestHelper {
     public void saveCardCheckBox_whenVisibleAndCustomerChecks_vaults() {
         setSaveCardCheckBox(true, false);
         setUniqueCustomerId();
+        launchApp();
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         onDevice(withText("Credit or Debit Card")).perform(click());
@@ -58,6 +60,7 @@ public class OptionalVaultingDropInTest extends TestHelper {
     public void saveCardCheckBox_whenVisibleAndCustomerUnchecks_doesNotVault() {
         setSaveCardCheckBox(true, true);
         setUniqueCustomerId();
+        launchApp();
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         onDevice(withText("Credit or Debit Card")).perform(click());
@@ -77,6 +80,7 @@ public class OptionalVaultingDropInTest extends TestHelper {
     public void saveCardCheckBox_whenGoneAndChecked_vaults() {
         setSaveCardCheckBox(false, true);
         setUniqueCustomerId();
+        launchApp();
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);
@@ -91,6 +95,7 @@ public class OptionalVaultingDropInTest extends TestHelper {
     public void saveCardCheckBox_whenGoneAndUnchecked_doesNotVault() {
         setSaveCardCheckBox(false, false);
         setUniqueCustomerId();
+        launchApp();
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/OptionalVaultingDropInTest.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/OptionalVaultingDropInTest.java
@@ -28,7 +28,6 @@ public class OptionalVaultingDropInTest extends TestHelper {
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);
-        onDevice(withText("Next")).perform(click());
 
         onDevice(withText("Visa")).waitForExists().perform(click());
         boolean hasSavedPaymentMethods = onDevice(withText("Recent")).waitForExists().exists();
@@ -81,7 +80,6 @@ public class OptionalVaultingDropInTest extends TestHelper {
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);
-        onDevice(withText("Next")).perform(click());
 
         onDevice(withText("Visa")).waitForExists().perform(click());
         boolean hasSavedPaymentMethods = onDevice(withText("Recent")).waitForExists().exists();
@@ -96,7 +94,6 @@ public class OptionalVaultingDropInTest extends TestHelper {
 
         onDevice(withText("Add Payment Method")).waitForExists().waitForEnabled().perform(click());
         tokenizeCard(VISA);
-        onDevice(withText("Next")).perform(click());
 
         onDevice(withText("Visa")).waitForExists().perform(click());
         boolean hasSavedPaymentMethods = onDevice(withText("Recent")).waitForExists().exists();

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
@@ -1,11 +1,7 @@
 package com.braintreepayments.demo.test.utilities;
 
-import android.Manifest;
 import android.content.Context;
-import android.content.pm.PackageManager;
-import android.os.SystemClock;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.widget.Spinner;
 
 import androidx.annotation.CallSuper;
@@ -13,9 +9,6 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.braintreepayments.DeviceAutomator;
 import com.braintreepayments.cardform.view.CardForm;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static com.braintreepayments.AutomatorAction.click;
 import static com.braintreepayments.AutomatorAction.setText;
@@ -26,11 +19,8 @@ import static com.braintreepayments.UiObjectMatcher.withResourceId;
 import static com.braintreepayments.UiObjectMatcher.withText;
 import static com.braintreepayments.UiObjectMatcher.withTextContaining;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assume.assumeFalse;
 
 public class TestHelper {
-
-    public static final String PAYPAL_WALLET_PACKAGE_NAME = "com.paypal.android.p2pmobile";
 
     @CallSuper
     public void setup() {
@@ -58,9 +48,6 @@ public class TestHelper {
                 .edit()
                 .putString("customer", customerId)
                 .commit();
-
-//        SystemClock.sleep(2000);
-//        onDevice(withText("Reset")).perform(click());
     }
 
     /**
@@ -76,9 +63,6 @@ public class TestHelper {
                 .edit()
                 .putString("merchant_account", merchantAccountId)
                 .commit();
-
-//        SystemClock.sleep(2000);
-//        onDevice(withText("Reset")).perform(click());
     }
 
     public void useTokenizationKey() {
@@ -86,11 +70,6 @@ public class TestHelper {
                 .edit()
                 .putBoolean("tokenization_key", true)
                 .commit();
-//
-//        // additional sleep here makes tests more consistent for some reason
-//        SystemClock.sleep(2000);
-//        onDevice(withText("Reset")).perform(click());
-//        SystemClock.sleep(2000);
     }
 
     public void enableThreeDSecure() {
@@ -127,9 +106,6 @@ public class TestHelper {
                 .edit()
                 .putString("cardholder_name_status", status)
                 .commit();
-
-//        SystemClock.sleep(2000);
-//        onDevice(withText("Reset")).perform(click());
     }
 
     public void setSaveCardCheckBox(boolean visible, boolean defaultValue) {
@@ -138,9 +114,6 @@ public class TestHelper {
                 .putBoolean("save_card_checkbox_visible", visible)
                 .putBoolean("save_card_checkbox_default_value", defaultValue)
                 .commit();
-
-//        SystemClock.sleep(2000);
-//        onDevice(withText("Reset")).perform(click());
     }
 
     private void clearPreference(String preference) {
@@ -157,16 +130,6 @@ public class TestHelper {
             onDevice(withClass(Spinner.class)).perform(click());
             onDevice(withText(environment)).perform(click());
             onDevice(withText(environment)).check(text(equalTo(environment)));
-        }
-    }
-
-    private static boolean isAppInstalled(String packageName) {
-        PackageManager pm = ApplicationProvider.getApplicationContext().getPackageManager();
-        try {
-            pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
-            return true;
-        } catch (PackageManager.NameNotFoundException e) {
-            return false;
         }
     }
 

--- a/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
+++ b/Demo/src/androidTest/java/com/braintreepayments/demo/test/utilities/TestHelper.java
@@ -42,7 +42,9 @@ public class TestHelper {
                 .clear()
                 .putBoolean("paypal_use_hardcoded_configuration", true)
                 .commit();
+    }
 
+    public void launchApp() {
         onDevice().onHomeScreen().launchApp("com.braintreepayments.demo");
         ensureEnvironmentIs("Sandbox");
     }
@@ -57,8 +59,8 @@ public class TestHelper {
                 .putString("customer", customerId)
                 .commit();
 
-        SystemClock.sleep(2000);
-        onDevice(withText("Reset")).perform(click());
+//        SystemClock.sleep(2000);
+//        onDevice(withText("Reset")).perform(click());
     }
 
     /**
@@ -75,8 +77,8 @@ public class TestHelper {
                 .putString("merchant_account", merchantAccountId)
                 .commit();
 
-        SystemClock.sleep(2000);
-        onDevice(withText("Reset")).perform(click());
+//        SystemClock.sleep(2000);
+//        onDevice(withText("Reset")).perform(click());
     }
 
     public void useTokenizationKey() {
@@ -84,11 +86,11 @@ public class TestHelper {
                 .edit()
                 .putBoolean("tokenization_key", true)
                 .commit();
-
-        // additional sleep here makes tests more consistent for some reason
-        SystemClock.sleep(2000);
-        onDevice(withText("Reset")).perform(click());
-        SystemClock.sleep(2000);
+//
+//        // additional sleep here makes tests more consistent for some reason
+//        SystemClock.sleep(2000);
+//        onDevice(withText("Reset")).perform(click());
+//        SystemClock.sleep(2000);
     }
 
     public void enableThreeDSecure() {
@@ -126,8 +128,8 @@ public class TestHelper {
                 .putString("cardholder_name_status", status)
                 .commit();
 
-        SystemClock.sleep(2000);
-        onDevice(withText("Reset")).perform(click());
+//        SystemClock.sleep(2000);
+//        onDevice(withText("Reset")).perform(click());
     }
 
     public void setSaveCardCheckBox(boolean visible, boolean defaultValue) {
@@ -137,8 +139,8 @@ public class TestHelper {
                 .putBoolean("save_card_checkbox_default_value", defaultValue)
                 .commit();
 
-        SystemClock.sleep(2000);
-        onDevice(withText("Reset")).perform(click());
+//        SystemClock.sleep(2000);
+//        onDevice(withText("Reset")).perform(click());
     }
 
     private void clearPreference(String preference) {

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
@@ -48,7 +48,11 @@ class SelectPaymentMethodParentFragmentUITest {
             val childFragmentManager = fragment.childFragmentManager
             val showVaultManagerEvent = DropInEvent(DropInEventType.SHOW_VAULT_MANAGER)
             childFragmentManager.setFragmentResult(DropInEvent.REQUEST_KEY, showVaultManagerEvent.toBundle())
+        }
 
+        onView(isRoot()).perform(waitFor(500))
+
+        scenario.onFragment { fragment ->
             val currentItemPos = fragment.viewPager.currentItem
             assertEquals(1, currentItemPos)
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
@@ -40,6 +40,7 @@ class SelectPaymentMethodParentFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onShowVaultManagerEvent_showsVaultManager() {
+        // TODO: determine how to test UI with animation delay
         val scenario =
                 FragmentScenario.launchInContainer(SelectPaymentMethodParentFragment::class.java)
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SelectPaymentMethodParentFragmentUITest.kt
@@ -40,7 +40,6 @@ class SelectPaymentMethodParentFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onShowVaultManagerEvent_showsVaultManager() {
-        // TODO: determine how to test UI with animation delay
         val scenario =
                 FragmentScenario.launchInContainer(SelectPaymentMethodParentFragment::class.java)
 


### PR DESCRIPTION
### Summary of changes

 - Move the code for launching the app for integration testing out of the `setup` method so it can be called after any additional settings changes have been set.
 - Clean up TestHelper
 - Get all tests in `androidTest` in the Demo app passing

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
