### PR TITLE
Android 12 Updates v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+* Android 12 Support
+  * Bump braintree_android module dependency versions to `4.6.0`
+  * Upgrade `targetSdkVersion` and `compileSdkVersion` to API 31
+  * Fix issue where Venmo app is not detected on Android 12 devices
+
 ## 6.0.0-beta1
 
 * Dependencies

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
@@ -71,7 +71,7 @@ dependencies {
 
     implementation project(':Drop-In')
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.braintreepayments:device-automator:1.0.0'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
 

--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
 
         <activity
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
 
     testImplementation "androidx.core:core-ktx:1.6.0"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10"
     testImplementation "androidx.test:core:1.4.0"
 
     androidTestImplementation 'androidx.test:rules:1.3.0'

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     testImplementation "androidx.core:core-ktx:1.6.0"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    testImplementation "androidx.test:core:1.3.0"
+    testImplementation "androidx.test:core:1.4.0"
 
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -65,14 +65,14 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.fragment:fragment:1.3.5'
 
-    api 'com.braintreepayments.api:braintree-core:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:three-d-secure:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:paypal:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:venmo:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:google-pay:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:card:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:data-collector:4.4.2-SNAPSHOT'
-    api 'com.braintreepayments.api:union-pay:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:braintree-core:4.6.0'
+    api 'com.braintreepayments.api:three-d-secure:4.6.0'
+    api 'com.braintreepayments.api:paypal:4.6.0'
+    api 'com.braintreepayments.api:venmo:4.6.0'
+    api 'com.braintreepayments.api:google-pay:4.6.0'
+    api 'com.braintreepayments.api:card:4.6.0'
+    api 'com.braintreepayments.api:data-collector:4.6.0'
+    api 'com.braintreepayments.api:union-pay:4.6.0'
 
     api 'com.braintreepayments:card-form:5.2.0'
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -65,14 +65,14 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.fragment:fragment:1.3.5'
 
-    api 'com.braintreepayments.api:braintree-core:4.4.1'
-    api 'com.braintreepayments.api:three-d-secure:4.4.1'
-    api 'com.braintreepayments.api:paypal:4.4.1'
-    api 'com.braintreepayments.api:venmo:4.4.1'
-    api 'com.braintreepayments.api:google-pay:4.4.1'
-    api 'com.braintreepayments.api:card:4.4.1'
-    api 'com.braintreepayments.api:data-collector:4.4.1'
-    api 'com.braintreepayments.api:union-pay:4.4.1'
+    api 'com.braintreepayments.api:braintree-core:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:three-d-secure:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:paypal:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:venmo:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:google-pay:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:card:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:data-collector:4.4.2-SNAPSHOT'
+    api 'com.braintreepayments.api:union-pay:4.4.2-SNAPSHOT'
 
     api 'com.braintreepayments:card-form:5.2.0'
 

--- a/Drop-In/src/main/AndroidManifest.xml
+++ b/Drop-In/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
 
         <activity android:name="com.braintreepayments.api.DropInActivity"
             android:theme="@style/bt_drop_in_activity_theme"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="${applicationId}.braintree" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         maven {
@@ -11,7 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ plugins {
 
 version '6.0.0-beta2-SNAPSHOT'
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     minSdkVersion = 21
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     versionCode = 86
     versionName = version
 }


### PR DESCRIPTION
### Summary of changes

  * Bump braintree_android module dependency versions to `4.6.0`
  * Upgrade `targetSdkVersion` and `compileSdkVersion` to API 31
  * Fix issue where Venmo app is not detected on Android 12 devices

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop
