### PR TITLE
Fix Cardholder Name Field Focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+* CardForm
+  * Focus Cardholder Name field when adding card details if field not disabled (fixes #180)
+
 ## 6.0.0-beta2
 
 * Android 12 Support

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
@@ -37,15 +37,45 @@ class CardDetailsFragmentUITest {
     }
 
     @Test
-    fun whenStateIsRESUMED_expirationDateFieldIsFocused() {
+    fun whenStateIsRESUMED_andCardholderNameDisabled_expirationDateFieldIsFocused() {
+        val dropInRequest = DropInRequest()
         val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
         args.putString("EXTRA_CARD_NUMBER", VISA)
         val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
+        assertEquals(CardForm.FIELD_DISABLED, dropInRequest.cardholderNameStatus)
         onView(withId(R.id.bt_card_form_expiration)).check(matches(isFocused()))
+    }
+
+    @Test
+    fun whenStateIsRESUMED_andCardholderNameOptional_cardholderNameFieldIsFocused() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_OPTIONAL
+        val args = Bundle()
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
+        args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
+        args.putString("EXTRA_CARD_NUMBER", VISA)
+        val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onView(withId(R.id.bt_card_form_cardholder_name)).check(matches(isFocused()))
+    }
+
+    @Test
+    fun whenStateIsRESUMED_andCardholderNameRequired_cardholderNameFieldIsFocused() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.cardholderNameStatus = FIELD_REQUIRED
+        val args = Bundle()
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
+        args.putParcelable("EXTRA_CARD_FORM_CONFIGURATION", CardFormConfiguration(false, false))
+        args.putString("EXTRA_CARD_NUMBER", VISA)
+        val scenario = FragmentScenario.launchInContainer(CardDetailsFragment::class.java, args, R.style.bt_drop_in_activity_theme)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onView(withId(R.id.bt_card_form_cardholder_name)).check(matches(isFocused()))
     }
 
     @Test

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -134,7 +134,11 @@ public class CardDetailsFragment extends DropInFragment implements OnCardFormSub
     @Override
     public void onResume() {
         super.onResume();
-        cardForm.getExpirationDateEditText().requestFocus();
+        if (dropInRequest.getCardholderNameStatus() == CardForm.FIELD_DISABLED) {
+            cardForm.getExpirationDateEditText().requestFocus();
+        } else {
+            cardForm.getCardholderNameEditText().requestFocus();
+        }
     }
 
     void setErrors(ErrorWithResponse errors) {


### PR DESCRIPTION
### Summary of changes

 - Focus Cardholder Name field when adding card details if field not disabled (fixes #180)
 - Currently the expiration date field is focused first when adding card details, even if the cardholder name field is displayed (i.e. not disabled). This PR updates the logic to focus the expiration date field only if cardholder name is disabled, otherwise focus cardholder name first. 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
