### PR TITLE
Compile with Java 8 to Fix Tests

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -30,8 +30,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7.toString()
-        targetCompatibility JavaVersion.VERSION_1_7.toString()
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     testOptions.unitTests {
@@ -97,9 +97,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10"
     testImplementation "androidx.test:core:1.4.0"
 
-    androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.fragment:fragment-testing:1.3.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 


### PR DESCRIPTION
### Summary of changes

 - Integration tests are currently failing with manifest merger errors (fixed by upgrading `androidx.text.ext.junit` version)
 - When junit is upgraded, tests fail with error solved [here](https://stackoverflow.com/questions/49891730/invoke-customs-are-only-supported-starting-with-android-0-min-api-26) by specifying Java 8 as compile version (instead of Java 7)
 - Unit tests fail in command line because of lint error - resolved by upgrading appcompat dependency to `1.4.0-alpha03`

**Note**: I tried to create a test Android app compiling with Java 7 and including drop-in as a dependency, and it worked before and after the change from compileOptions Java 7 to Java 8 in this PR - I can't confirm that nothing will break depending on gradle versions, but since this is a major version update it seems like a good time to make this change to ensure we don't have future conflicts as we try to use Java 11 for testing and other updated libraries. 

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
