### PR TITLE
Set `sessionId` and `integrationType` in `DropInClient`

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -59,7 +59,6 @@ public class DropInClient {
     }
 
     DropInClient(Context context, String authorization, String sessionId, DropInRequest dropInRequest) {
-        // TODO: instantiate a BraintreeClient with the input sessionId
         this(createDefaultParams(context, authorization, dropInRequest, sessionId));
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -26,7 +26,8 @@ public class DropInClient {
     static final String LAST_USED_PAYMENT_METHOD_TYPE =
             "com.braintreepayments.api.dropin.LAST_USED_PAYMENT_METHOD_TYPE";
 
-    private final BraintreeClient braintreeClient;
+    @VisibleForTesting
+    final BraintreeClient braintreeClient;
     private final PaymentMethodClient paymentMethodClient;
     private final GooglePayClient googlePayClient;
     private final PayPalClient payPalClient;
@@ -38,8 +39,8 @@ public class DropInClient {
     private final ThreeDSecureClient threeDSecureClient;
     private final DataCollector dataCollector;
 
-    private static DropInClientParams createDefaultParams(Context context, String authorization, DropInRequest dropInRequest) {
-        BraintreeClient braintreeClient = new BraintreeClient(context, authorization);
+    private static DropInClientParams createDefaultParams(Context context, String authorization, DropInRequest dropInRequest, String sessionId) {
+        BraintreeClient braintreeClient = new BraintreeClient(context, authorization, sessionId, IntegrationType.DROP_IN);
         return new DropInClientParams()
                 .dropInRequest(dropInRequest)
                 .braintreeClient(braintreeClient)
@@ -59,7 +60,7 @@ public class DropInClient {
 
     DropInClient(Context context, String authorization, String sessionId, DropInRequest dropInRequest) {
         // TODO: instantiate a BraintreeClient with the input sessionId
-        this(createDefaultParams(context, authorization, dropInRequest));
+        this(createDefaultParams(context, authorization, dropInRequest, sessionId));
     }
 
     @VisibleForTesting

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
@@ -53,12 +53,20 @@ class DropInActivityTest {
     }
 
     @Test
-    fun onCreate_setsIntegrationTypeToDropinForDropinActivity() {
-        setupDropInActivity(mock(DropInClient::class.java), dropInRequest)
+    fun onCreate_createsClientsWithExtrasFromIntent() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(context, DropInActivity::class.java)
+        intent.putExtra(DropInClient.EXTRA_CHECKOUT_REQUEST, dropInRequest)
+        intent.putExtra(DropInClient.EXTRA_AUTHORIZATION, Fixtures.TOKENIZATION_KEY)
+        intent.putExtra(DropInClient.EXTRA_SESSION_ID, "session-id")
 
-        // TODO: revisit integration type metadata and consider passing integration (core PR)
-        // type through BraintreeClient constructor instead of relying on reflection
-//        assertEquals("dropin3", mActivity.getDropInClient().getIntegrationType());
+        activityController = buildActivity(DropInActivity::class.java, intent)
+        activity = activityController.get()
+        activityController.setup()
+
+        assertSame(dropInRequest, activity.dropInRequest)
+        assertEquals("session-id", activity.dropInClient.braintreeClient.sessionId)
+        assertEquals(Fixtures.TOKENIZATION_KEY, activity.dropInClient.braintreeClient.authorization.toString())
     }
 
     // endregion

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -65,9 +65,15 @@ public class DropInClientUnitTest {
     }
 
     @Test
-    public void constructor_setsBraintreeClientWithSessionId() {
+    public void publicConstructor_setsBraintreeClientWithSessionId() {
         DropInClient sut = new DropInClient(ApplicationProvider.getApplicationContext(), Fixtures.TOKENIZATION_KEY, new DropInRequest());
         assertNotNull(sut.braintreeClient.getSessionId());
+    }
+
+    @Test
+    public void internalConstructor_setsBraintreeClientWithSessionId() {
+        DropInClient sut = new DropInClient(ApplicationProvider.getApplicationContext(), Fixtures.TOKENIZATION_KEY, "session-id", new DropInRequest());
+        assertEquals("session-id", sut.braintreeClient.getSessionId());
     }
 
     @Test

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -18,6 +19,7 @@ import android.content.Intent;
 import android.net.Uri;
 
 import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ApplicationProvider;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -54,6 +56,18 @@ public class DropInClientUnitTest {
         ActivityController<FragmentActivity> activityController =
                 Robolectric.buildActivity(FragmentActivity.class);
         activity = activityController.get();
+    }
+
+    @Test
+    public void constructor_setsIntegrationTypeDropIn() {
+        DropInClient sut = new DropInClient(ApplicationProvider.getApplicationContext(), Fixtures.TOKENIZATION_KEY, new DropInRequest());
+        assertEquals(IntegrationType.DROP_IN, sut.braintreeClient.getIntegrationType());
+    }
+
+    @Test
+    public void constructor_setsBraintreeClientWithSessionId() {
+        DropInClient sut = new DropInClient(ApplicationProvider.getApplicationContext(), Fixtures.TOKENIZATION_KEY, new DropInRequest());
+        assertNotNull(sut.braintreeClient.getSessionId());
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Set `sessionId` and `integrationType` in `DropInClient` (this allows for the same session ID to be used for analytics events throughout the Drop-in flow)

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
