### PR TITLE
Accessibility Updates (Contrast and TalkBack descriptions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * DropInRequest
   * Set explicit class loader for `DropInRequest` (fixes #191)
   * Wrap `DropInRequest` in Parcelable bundle (fixes #228)
+* Accessibility
+  * Increase color contrast and add content descriptions for screen readers
 * Breaking Changes
   * Language Support
     * Require Java 8 or higher

--- a/Demo/src/main/res/values/themes.xml
+++ b/Demo/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="DemoAppTheme" parent="Theme.AppCompat.Light">
-        <item name="colorAccent">@color/bt_blue_contrast</item>
+        <item name="colorAccent">@color/bt_black_contrast</item>
     </style>
 </resources>

--- a/Demo/src/main/res/values/themes.xml
+++ b/Demo/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="DemoAppTheme" parent="Theme.AppCompat.Light">
-        <item name="colorAccent">@color/bt_blue</item>
+        <item name="colorAccent">@color/bt_blue_contrast</item>
     </style>
 </resources>

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -80,6 +80,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
         });
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
+        toolbar.setNavigationContentDescription(R.string.bt_back);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         sendAnalyticsEvent("card.selected");

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -81,6 +81,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
         toolbar.setNavigationContentDescription(R.string.bt_back);
+        toolbar.setTouchScreenBlocksFocus(false);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         sendAnalyticsEvent("card.selected");

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -81,7 +81,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
         toolbar.setNavigationContentDescription(R.string.bt_back);
-        toolbar.setTouchScreenBlocksFocus(false);
+        toolbar.setTouchscreenBlocksFocus(false);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         sendAnalyticsEvent("card.selected");

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -80,6 +80,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
         });
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
+        // Add a label to the toolbar back button for the screen reader and make it accessible via tab navigation
         toolbar.setNavigationContentDescription(R.string.bt_back);
         toolbar.setTouchscreenBlocksFocus(false);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -91,6 +91,7 @@ public class CardDetailsFragment extends DropInFragment implements OnCardFormSub
                 });
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
+        toolbar.setNavigationContentDescription(R.string.bt_back);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.getAllowVaultCardOverride();

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -92,7 +92,7 @@ public class CardDetailsFragment extends DropInFragment implements OnCardFormSub
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
         toolbar.setNavigationContentDescription(R.string.bt_back);
-        toolbar.setTouchScreenBlocksFocus(false);
+        toolbar.setTouchscreenBlocksFocus(false);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.getAllowVaultCardOverride();

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -92,6 +92,7 @@ public class CardDetailsFragment extends DropInFragment implements OnCardFormSub
 
         Toolbar toolbar = view.findViewById(R.id.bt_toolbar);
         toolbar.setNavigationContentDescription(R.string.bt_back);
+        toolbar.setTouchScreenBlocksFocus(false);
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
         boolean showCardCheckbox = !isTokenizationKeyAuth && dropInRequest.getAllowVaultCardOverride();

--- a/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodItemView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodItemView.java
@@ -75,8 +75,8 @@ class PaymentMethodItemView extends LinearLayout {
     public void setOnDeleteIconClick(OnClickListener clickListener) {
         deleteIcon.setOnClickListener(clickListener);
         String deleteString = getContext().getString(R.string.bt_delete);
-        String paymentType = nonceInspector.getTypeLabel(paymentMethodNonce);
-        String paymentDescription = nonceInspector.getDescription(paymentMethodNonce);
+        String paymentType = nonceInspector.getPaymentMethod(paymentMethodNonce).name();
+        String paymentDescription = nonceInspector.getPaymentMethodDescription(paymentMethodNonce);
         String contentDescription = String.format("%s %s %s", deleteString, paymentType, paymentDescription);
         deleteIcon.setContentDescription(contentDescription);
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodItemView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodItemView.java
@@ -74,6 +74,11 @@ class PaymentMethodItemView extends LinearLayout {
 
     public void setOnDeleteIconClick(OnClickListener clickListener) {
         deleteIcon.setOnClickListener(clickListener);
+        String deleteString = getContext().getString(R.string.bt_delete);
+        String paymentType = nonceInspector.getTypeLabel(paymentMethodNonce);
+        String paymentDescription = nonceInspector.getDescription(paymentMethodNonce);
+        String contentDescription = String.format("%s %s %s", deleteString, paymentType, paymentDescription);
+        deleteIcon.setContentDescription(contentDescription);
     }
 
     public PaymentMethodNonce getPaymentMethodNonce() {

--- a/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
+++ b/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
@@ -4,5 +4,5 @@
     tools:ignore="UnusedAttribute"
     android:exitFadeDuration="@android:integer/config_shortAnimTime" >
     <item android:drawable="@color/bt_blue_pressed" android:state_pressed="true" />
-    <item android:drawable="@color/bt_blue_contrast" />
+    <item android:drawable="@color/bt_black_contrast" />
 </selector>

--- a/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
+++ b/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
@@ -4,5 +4,5 @@
     tools:ignore="UnusedAttribute"
     android:exitFadeDuration="@android:integer/config_shortAnimTime" >
     <item android:drawable="@color/bt_blue_pressed" android:state_pressed="true" />
-    <item android:drawable="@color/bt_black_contrast" />
+    <item android:drawable="@color/bt_blue" />
 </selector>

--- a/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
+++ b/Drop-In/src/main/res/drawable/bt_submit_button_background.xml
@@ -4,5 +4,5 @@
     tools:ignore="UnusedAttribute"
     android:exitFadeDuration="@android:integer/config_shortAnimTime" >
     <item android:drawable="@color/bt_blue_pressed" android:state_pressed="true" />
-    <item android:drawable="@color/bt_blue" />
+    <item android:drawable="@color/bt_blue_contrast" />
 </selector>

--- a/Drop-In/src/main/res/layout/bt_animated_button_view.xml
+++ b/Drop-In/src/main/res/layout/bt_animated_button_view.xml
@@ -10,7 +10,7 @@
             android:id="@+id/bt_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/bt_blue_contrast"
+            android:background="@color/bt_black_contrast"
             android:textColor="@color/bt_white"/>
 
         <ProgressBar

--- a/Drop-In/src/main/res/layout/bt_animated_button_view.xml
+++ b/Drop-In/src/main/res/layout/bt_animated_button_view.xml
@@ -10,7 +10,7 @@
             android:id="@+id/bt_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/bt_blue"
+            android:background="@color/bt_blue_contrast"
             android:textColor="@color/bt_white"/>
 
         <ProgressBar

--- a/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
@@ -33,7 +33,8 @@
                     android:layout_alignParentEnd="true"
                     android:text="@string/bt_edit"
                     android:theme="@style/bt_edit_button"
-                    android:visibility="invisible" />
+                    android:visibility="invisible"
+                    android:contentDescription="@string/bt_edit_button_description"/>
 
                 <TextView
                     android:id="@+id/bt_vaulted_payment_methods_header"
@@ -54,7 +55,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingLeft="4dp"
-                android:paddingRight="4dp" />
+                android:paddingRight="4dp"
+                android:contentDescription="@string/bt_saved_payments"/>
 
             <include layout="@layout/bt_section_divider" />
 
@@ -72,7 +74,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingLeft="4dp"
-            android:paddingRight="4dp" />
+            android:paddingRight="4dp"
+            android:contentDescription="@string/bt_supported_payments"/>
 
     </LinearLayout>
 

--- a/Drop-In/src/main/res/values-es-rXC/strings.xml
+++ b/Drop-In/src/main/res/values-es-rXC/strings.xml
@@ -9,7 +9,6 @@
     <string name="bt_descriptor_maestro">Maestro</string>
     <string name="bt_descriptor_paypal">PayPal</string>
     <string name="bt_descriptor_pay_with_venmo">Venmo</string>
-    <string name="bt_descriptorandroid_pay">Android Pay</string>
     <string name="bt_descriptor_google_pay">Google Pay</string>
     <string name="bt_descriptor_unionpay">UnionPay</string>
     <string name="bt_descriptor_hiper">Hiper</string>

--- a/Drop-In/src/main/res/values/colors.xml
+++ b/Drop-In/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <color name="bt_color_primary_dark">#363439</color>
     <color name="bt_text_blue">#199DDC</color>
     <color name="bt_error_red">#D73333</color>
-    <color name="bt_blue_contrast">#007DB3</color>
+    <color name="bt_blue_contrast">#0079AD</color>
 
     <!-- HACK: make card form dark icons show up, but allow for full transparency of drop in activity window background -->
     <color name="bt_window_background">#00FFFFFF</color>

--- a/Drop-In/src/main/res/values/colors.xml
+++ b/Drop-In/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <color name="bt_color_primary_dark">#363439</color>
     <color name="bt_text_blue">#199DDC</color>
     <color name="bt_error_red">#D73333</color>
-    <color name="bt_blue_contrast">#0079AD</color>
+    <color name="bt_black_contrast">#000000</color>
 
     <!-- HACK: make card form dark icons show up, but allow for full transparency of drop in activity window background -->
     <color name="bt_window_background">#00FFFFFF</color>

--- a/Drop-In/src/main/res/values/colors.xml
+++ b/Drop-In/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
     <color name="bt_white_pressed">#F2F2F2</color>
     <color name="bt_base_background">#FAFAFA</color>
     <color name="bt_base_background_translucent">#AAFAFAFA</color>
-    <color name="bt_blue_pressed">#0076A8</color>
+    <color name="bt_blue_pressed">#008BC7</color>
     <color name="bt_very_light_gray">#E2E2E3</color>
     <color name="bt_button_disabled_color">#99999A</color>
     <color name="bt_paypal_monogram_button_background">#009CDE</color>

--- a/Drop-In/src/main/res/values/colors.xml
+++ b/Drop-In/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
     <color name="bt_white_pressed">#F2F2F2</color>
     <color name="bt_base_background">#FAFAFA</color>
     <color name="bt_base_background_translucent">#AAFAFAFA</color>
-    <color name="bt_blue_pressed">#008BC7</color>
+    <color name="bt_blue_pressed">#0076A8</color>
     <color name="bt_very_light_gray">#E2E2E3</color>
     <color name="bt_button_disabled_color">#99999A</color>
     <color name="bt_paypal_monogram_button_background">#009CDE</color>
@@ -13,7 +13,8 @@
     <color name="bt_color_highlight">#9F9EA1</color>
     <color name="bt_color_primary_dark">#363439</color>
     <color name="bt_text_blue">#199DDC</color>
-    <color name="bt_error_red">#DD5555</color>
+    <color name="bt_error_red">#D73333</color>
+    <color name="bt_blue_contrast">#007DB3</color>
 
     <!-- HACK: make card form dark icons show up, but allow for full transparency of drop in activity window background -->
     <color name="bt_window_background">#00FFFFFF</color>

--- a/Drop-In/src/main/res/values/styles.xml
+++ b/Drop-In/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
 
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue_contrast</item>
+        <item name="colorAccent">@color/bt_black_contrast</item>
         <item name="titleTextColor">@color/bt_white</item>
         <item name="colorError">@color/bt_error_red</item>
     </style>
@@ -30,7 +30,7 @@
         <item name="windowNoTitle">true</item>
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue_contrast</item>
+        <item name="colorAccent">@color/bt_black_contrast</item>
         <item name="titleTextColor">@color/bt_white</item>
         <item name="colorError">@color/bt_error_red</item>
     </style>
@@ -45,7 +45,7 @@
         <item name="android:windowAnimationStyle">@style/bt_activity_slide_animation</item>
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue_contrast</item>
+        <item name="colorAccent">@color/bt_black_contrast</item>
     </style>
 
     <style name="bt_three_d_secure_theme" parent="@android:style/Theme.Holo.Light">
@@ -90,7 +90,7 @@
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Borderless.Colored</item>
         <item name="colorControlHighlight">@color/bt_color_highlight</item>
         <item name="android:textSize">16sp</item>
-        <item name="colorAccent">@color/bt_blue_contrast</item>
+        <item name="colorAccent">@color/bt_black_contrast</item>
         <item name="android:textAllCaps">true</item>
     </style>
 </resources>

--- a/Drop-In/src/main/res/values/styles.xml
+++ b/Drop-In/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
 
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue</item>
+        <item name="colorAccent">@color/bt_blue_contrast</item>
         <item name="titleTextColor">@color/bt_white</item>
         <item name="colorError">@color/bt_error_red</item>
     </style>
@@ -30,7 +30,7 @@
         <item name="windowNoTitle">true</item>
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue</item>
+        <item name="colorAccent">@color/bt_blue_contrast</item>
         <item name="titleTextColor">@color/bt_white</item>
         <item name="colorError">@color/bt_error_red</item>
     </style>
@@ -45,7 +45,7 @@
         <item name="android:windowAnimationStyle">@style/bt_activity_slide_animation</item>
         <item name="colorPrimary">@color/bt_color_primary</item>
         <item name="colorPrimaryDark">@color/bt_color_primary_dark</item>
-        <item name="colorAccent">@color/bt_blue</item>
+        <item name="colorAccent">@color/bt_blue_contrast</item>
     </style>
 
     <style name="bt_three_d_secure_theme" parent="@android:style/Theme.Holo.Light">

--- a/Drop-In/src/main/res/values/styles.xml
+++ b/Drop-In/src/main/res/values/styles.xml
@@ -90,7 +90,7 @@
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Borderless.Colored</item>
         <item name="colorControlHighlight">@color/bt_color_highlight</item>
         <item name="android:textSize">16sp</item>
-        <item name="colorAccent">@color/bt_text_blue</item>
+        <item name="colorAccent">@color/bt_blue_contrast</item>
         <item name="android:textAllCaps">true</item>
     </style>
 </resources>


### PR DESCRIPTION
### Summary of changes

 - Increase blue/white contrast in add card buttons and text field highlighting
 - Increase red/white contrast in error text
 - Add tab navigation and content description (for screen reader) to toolbar back buttons
 - Add content descriptions to payment method lists and vault manager delete icons

**Note:** I used the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/) and took the `bt_blue` and `bt_error_red` and dragged the colors darker to get `bt_blue_contrast` and the new `bt_error_red`. I'm not sure if the `bt_blue_contrast` is as aesthetically pleasing, so also showing the option to change the color completely to the PayPal dark blue. Included screenshots of all below. 

**Before**
![Screen Shot 2021-10-29 at 10 31 00 AM](https://user-images.githubusercontent.com/67924275/139463048-b4bce6a7-ba2b-418d-be41-b487f70fcc35.png)

**After**
![Screen Shot 2021-10-29 at 10 31 42 AM](https://user-images.githubusercontent.com/67924275/139463066-b180a3d0-8156-47ae-94de-d930c0849bd8.png)

**Potential Change - PayPal Blue**
![Screen Shot 2021-10-29 at 10 34 04 AM](https://user-images.githubusercontent.com/67924275/139464407-cff93af3-873b-4276-aba0-f0bec27264c9.png)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
