### PR TITLE
Update Accessing SharedPreferences

### DIFF
--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -363,8 +363,8 @@ public class DropInClient {
             return;
         }
 
-        final DropInPaymentMethodType lastUsedPaymentMethodType = DropInPaymentMethodType.forType(BraintreeSharedPreferences.getSharedPreferences(activity)
-                .getString(LAST_USED_PAYMENT_METHOD_TYPE, null));
+        final DropInPaymentMethodType lastUsedPaymentMethodType = DropInPaymentMethodType.forType(BraintreeSharedPreferences.getInstance()
+                .getString(activity, LAST_USED_PAYMENT_METHOD_TYPE, null));
 
         if (lastUsedPaymentMethodType == DropInPaymentMethodType.GOOGLE_PAY) {
             googlePayClient.isReadyToPay(activity, (isReadyToPay, error) -> {

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInResult.java
@@ -98,11 +98,9 @@ public class DropInResult implements Parcelable {
 
     static void setLastUsedPaymentMethodType(Context context,
                                              PaymentMethodNonce paymentMethodNonce) {
-        BraintreeSharedPreferences.getSharedPreferences(context)
-                .edit()
-                .putString(DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
-                        DropInPaymentMethodType.forType(paymentMethodNonce).getCanonicalName())
-                .apply();
+        BraintreeSharedPreferences.getInstance().putString(context,
+                DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
+                DropInPaymentMethodType.forType(paymentMethodNonce).getCanonicalName());
     }
 
     @Override

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
@@ -169,8 +169,8 @@ class DropInActivityTest {
         setupDropInActivity(dropInClient, dropInRequest)
 
         assertEquals(DropInPaymentMethodType.VISA.canonicalName,
-            BraintreeSharedPreferences.getSharedPreferences(activity)
-                .getString(DropInResult.LAST_USED_PAYMENT_METHOD_TYPE, null))
+            BraintreeSharedPreferences.getInstance()
+                .getString(activity, DropInResult.LAST_USED_PAYMENT_METHOD_TYPE, null))
     }
 
     // endregion

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -482,11 +482,9 @@ public class DropInClientUnitTest {
 
     @Test
     public void fetchMostRecentPaymentMethod_callsBackWithResultIfLastUsedPaymentMethodTypeWasPayWithGoogle() throws JSONException {
-        BraintreeSharedPreferences.getSharedPreferences(activity)
-                .edit()
-                .putString(DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
-                        DropInPaymentMethodType.GOOGLE_PAY.getCanonicalName())
-                .commit();
+        BraintreeSharedPreferences.getInstance().putString(activity,
+                DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
+                DropInPaymentMethodType.GOOGLE_PAY.getCanonicalName());
 
         GooglePayClient googlePayClient = new MockGooglePayClientBuilder()
                 .isReadyToPaySuccess(true)
@@ -517,11 +515,9 @@ public class DropInClientUnitTest {
     @Test
     public void fetchMostRecentPaymentMethod_doesNotCallBackWithPayWithGoogleIfPayWithGoogleIsNotAvailable()
             throws JSONException {
-        BraintreeSharedPreferences.getSharedPreferences(activity)
-                .edit()
-                .putString(DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
-                        DropInPaymentMethodType.GOOGLE_PAY.getCanonicalName())
-                .commit();
+        BraintreeSharedPreferences.getInstance().putString(activity,
+                DropInResult.LAST_USED_PAYMENT_METHOD_TYPE,
+                DropInPaymentMethodType.GOOGLE_PAY.getCanonicalName());
 
         GooglePayClient googlePayClient = new MockGooglePayClientBuilder()
                 .isReadyToPaySuccess(false)


### PR DESCRIPTION
### Summary of changes

 - We updated braintree_android to use EncryptedSharedPreferences and provided a `getInstance` and helper `getString` and `putString` methods for accessing shared preferences. This PR updates drop-in to use those methods to interact with shared preferences

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
