### PR TITLE
Payment Method Fragment Accessibility

### DIFF
--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/BottomSheetFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/BottomSheetFragmentUITest.kt
@@ -151,7 +151,7 @@ class BottomSheetFragmentUITest {
         }
 
         onView(isRoot()).perform(waitFor(1000))
-        onView(withId(R.id.back_button)).perform(click())
+        onView(withId(R.id.bt_cancel_button)).perform(click())
         onView(isRoot()).perform(waitFor(1000))
 
         assertEquals(BottomSheetState.HIDDEN, viewModel.bottomSheetState.value)

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -358,4 +358,18 @@ class SupportedPaymentMethodsFragmentUITest {
         onView(withId(R.id.bt_select_payment_method_loader_wrapper)).check(matches(isDisplayed()))
         onView(withId(R.id.bt_supported_payment_methods)).check(matches(not(isDisplayed())))
     }
+
+    @Test
+    fun whenCancelButtonClicked_setsBottomSheetStateToHideRequested() {
+        dropInRequest.isVaultManagerEnabled = true
+
+        val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
+
+        val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        onView(withId(R.id.bt_cancel_button)).perform(click())
+        scenario.onFragment { fragment ->
+            assertEquals(BottomSheetState.HIDE_REQUESTED, fragment.dropInViewModel.bottomSheetState.value)
+        }
+    }
 }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -164,7 +164,7 @@ class SupportedPaymentMethodsFragmentUITest {
             fragment.dropInViewModel.setHasFetchedPaymentMethods(true)
         }
 
-        onView(withId(R.id.bt_supported_payment_methods_header)).check(matches((isDisplayed())))
+        onView(withId(R.id.bt_supported_payment_methods)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
         onView(withId(R.id.bt_vaulted_payment_methods_header)).check(matches(not(isDisplayed())))
     }
 
@@ -202,7 +202,7 @@ class SupportedPaymentMethodsFragmentUITest {
             fragment.dropInViewModel.setHasFetchedPaymentMethods(true)
         }
 
-        onView(withId(R.id.bt_vaulted_payment_methods_wrapper)).check(matches(isDisplayed()))
+        onView(withId(R.id.bt_vaulted_payment_methods_wrapper)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
         onView(withId(R.id.bt_vault_edit_button)).check(matches(not(isDisplayed())))
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/BottomSheetFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/BottomSheetFragment.java
@@ -95,9 +95,6 @@ public class BottomSheetFragment extends Fragment implements BottomSheetPresente
             }
         });
 
-        Button backButton = view.findViewById(R.id.back_button);
-        backButton.setOnClickListener(v -> slideDownBottomSheet());
-
         bottomSheetPresenter = new BottomSheetPresenter();
         bottomSheetPresenter.bind(this);
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -126,6 +126,9 @@ public class DropInActivity extends AppCompatActivity {
                     }
                     if (paymentMethods != null) {
                         dropInViewModel.setSupportedPaymentMethods(paymentMethods);
+                    } else {
+                        onError(new BraintreeException("No payment methods supported"));
+                        return;
                     }
                     if (paymentMethodNonceList != null){
                         dropInViewModel.setVaultedPaymentMethods(paymentMethodNonceList);

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -115,7 +115,7 @@ public class DropInActivity extends AppCompatActivity {
 
         showBottomSheet();
     }
-    void fetchPaymentMethods(){
+    void fetchPaymentMethods() {
         dropInClient.getVaultedPaymentMethods(this, (paymentMethodNonceList, error) -> {
             if (error != null) {
                 onError(error);

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -147,10 +147,6 @@ public class DropInClient {
     }
 
     void requestGooglePayPayment(FragmentActivity activity, GooglePayRequestPaymentCallback callback) {
-        if (dropInRequest.getGooglePayRequest() == null) {
-            // TODO: unit test
-            callback.onResult(new BraintreeException("GooglePayRequest cannot be null."));
-        }
         googlePayClient.requestPayment(activity, dropInRequest.getGooglePayRequest(), callback);
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -147,6 +147,10 @@ public class DropInClient {
     }
 
     void requestGooglePayPayment(FragmentActivity activity, GooglePayRequestPaymentCallback callback) {
+        if (dropInRequest.getGooglePayRequest() == null) {
+            // TODO: unit test
+            callback.onResult(new BraintreeException("GooglePayRequest cannot be null."));
+        }
         googlePayClient.requestPayment(activity, dropInRequest.getGooglePayRequest(), callback);
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInViewModel.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInViewModel.java
@@ -21,6 +21,15 @@ public class DropInViewModel extends ViewModel {
     private final MutableLiveData<Exception> cardTokenizationError = new MutableLiveData<>();
     private final MutableLiveData<Exception> userCanceledError = new MutableLiveData<>();
 
+    public MutableLiveData<Boolean> getHasFetchedPaymentMethods() {
+        return hasFetchedPaymentMethods;
+    }
+    void setHasFetchedPaymentMethods(Boolean value) {
+        hasFetchedPaymentMethods.setValue(value);
+    }
+
+    private final MutableLiveData<Boolean> hasFetchedPaymentMethods = new MutableLiveData<>();
+
     LiveData<BottomSheetState> getBottomSheetState() {
         return bottomSheetState;
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -198,7 +198,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         }
         
         if (paymentMethodNonces != null && paymentMethodNonces.size() > 0) {
-            supportedPaymentMethodsHeader.setText(R.string.bt_other);
+            supportedPaymentMethodsHeader.setVisibility(View.VISIBLE);
             vaultedPaymentMethodsContainer.setVisibility(View.VISIBLE);
 
             VaultedPaymentMethodsAdapter vaultedPaymentMethodsAdapter =
@@ -211,7 +211,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
             }
 
         } else {
-            supportedPaymentMethodsHeader.setText(R.string.bt_select_payment_method);
+            supportedPaymentMethodsHeader.setVisibility(View.GONE);
             vaultedPaymentMethodsContainer.setVisibility(View.GONE);
         }
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -74,7 +74,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         vaultedPaymentMethodsContainer = view.findViewById(R.id.bt_vaulted_payment_methods_wrapper);
         vaultedPaymentMethodsView = view.findViewById(R.id.bt_vaulted_payment_methods);
         vaultManagerButton = view.findViewById(R.id.bt_vault_edit_button);
-//        cancelButton = view.findViewById(R.id.bt_cancel_button);
+        cancelButton = view.findViewById(R.id.bt_cancel_button);
 
         LinearLayoutManager supportedPaymentMethodsLayoutManager =
                 new LinearLayoutManager(requireActivity(), LinearLayoutManager.VERTICAL, false);
@@ -114,6 +114,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
 
         vaultManagerButton.setOnClickListener(v -> sendDropInEvent(new DropInEvent(DropInEventType.SHOW_VAULT_MANAGER)));
 
+        cancelButton.setOnClickListener(v -> dropInViewModel.setBottomSheetState(BottomSheetState.HIDE_REQUESTED));
         sendAnalyticsEvent("appeared");
         return view;
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -94,9 +94,8 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         }
 
         dropInViewModel.getHasFetchedPaymentMethods().observe(getViewLifecycleOwner(), hasFetched -> {
-            if (hasSupportedPaymentMethods() || hasVaultedPaymentMethods()) {
+            if (hasSupportedPaymentMethods()) {
                 setViewState(ViewState.SHOW_PAYMENT_METHODS);
-                refreshView();
             }
         });
 
@@ -107,7 +106,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         });
 
         dropInViewModel.getUserCanceledError().observe(getViewLifecycleOwner(), exception -> {
-            if(exception instanceof UserCanceledException){
+            if(exception instanceof UserCanceledException && hasSupportedPaymentMethods()){
                 setViewState(ViewState.SHOW_PAYMENT_METHODS);
             }
         });

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -87,31 +87,17 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         new LinearSnapHelper().attachToRecyclerView(vaultedPaymentMethodsView);
 
         dropInViewModel = new ViewModelProvider(requireActivity()).get(DropInViewModel.class);
-        if (hasSupportedPaymentMethods()) {
-            setViewState(ViewState.SHOW_PAYMENT_METHODS);
-        } else {
+        if (!hasSupportedPaymentMethods()) {
             setViewState(ViewState.LOADING);
         }
-
-//        dropInViewModel.getSupportedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodTypes -> {
-//            if (hasSupportedPaymentMethods()) {
-//            }
-//        });
-
-//        dropInViewModel.getVaultedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodNonces -> {
-//            if (hasVaultedPaymentMethods()) {
-//                setViewState(ViewState.SHOW_PAYMENT_METHODS);
-//                refreshView();
-//            }
-//        });
 
         dropInViewModel.getHasFetchedPaymentMethods().observe(getViewLifecycleOwner(), hasFetched -> {
             if (hasSupportedPaymentMethods() || hasVaultedPaymentMethods()) {
                 setViewState(ViewState.SHOW_PAYMENT_METHODS);
                 refreshView();
             }
-
         });
+
         dropInViewModel.getDropInState().observe(getViewLifecycleOwner(), dropInState -> {
             if (dropInState == DropInState.WILL_FINISH) {
                 setViewState(ViewState.DROP_IN_FINISHING);
@@ -133,10 +119,6 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
     @Override
     public void onResume() {
         super.onResume();
-
-        if (viewState == ViewState.LOADING && hasSupportedPaymentMethods()) {
-            setViewState(ViewState.SHOW_PAYMENT_METHODS);
-        }
     }
 
     private boolean hasSupportedPaymentMethods() {
@@ -162,11 +144,11 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
                 showLoader();
                 break;
             case SHOW_PAYMENT_METHODS:
-                hideLoader();
                 showSupportedPaymentMethods();
                 if (hasVaultedPaymentMethods()) {
                     showVaultedPaymentMethods();
                 }
+                hideLoader();
                 break;
         }
     }

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -41,6 +41,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
 
     private View vaultedPaymentMethodsContainer;
     private Button vaultManagerButton;
+    private Button cancelButton;
 
     private DropInRequest dropInRequest;
 
@@ -73,6 +74,7 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
         vaultedPaymentMethodsContainer = view.findViewById(R.id.bt_vaulted_payment_methods_wrapper);
         vaultedPaymentMethodsView = view.findViewById(R.id.bt_vaulted_payment_methods);
         vaultManagerButton = view.findViewById(R.id.bt_vault_edit_button);
+//        cancelButton = view.findViewById(R.id.bt_cancel_button);
 
         LinearLayoutManager supportedPaymentMethodsLayoutManager =
                 new LinearLayoutManager(requireActivity(), LinearLayoutManager.VERTICAL, false);

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -93,21 +93,34 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
             setViewState(ViewState.LOADING);
         }
 
-        dropInViewModel.getSupportedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodTypes -> {
-            if (hasSupportedPaymentMethods()) {
-                setViewState(ViewState.SHOW_PAYMENT_METHODS);
-            }
-        });
+//        dropInViewModel.getSupportedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodTypes -> {
+//            if (hasSupportedPaymentMethods()) {
+//            }
+//        });
 
-        dropInViewModel.getVaultedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodNonces -> {
-            if (hasVaultedPaymentMethods()) {
+//        dropInViewModel.getVaultedPaymentMethods().observe(getViewLifecycleOwner(), paymentMethodNonces -> {
+//            if (hasVaultedPaymentMethods()) {
+//                setViewState(ViewState.SHOW_PAYMENT_METHODS);
+//                refreshView();
+//            }
+//        });
+
+        dropInViewModel.getHasFetchedPaymentMethods().observe(getViewLifecycleOwner(), hasFetched -> {
+            if (hasSupportedPaymentMethods() || hasVaultedPaymentMethods()) {
+                setViewState(ViewState.SHOW_PAYMENT_METHODS);
                 refreshView();
             }
-        });
 
+        });
         dropInViewModel.getDropInState().observe(getViewLifecycleOwner(), dropInState -> {
             if (dropInState == DropInState.WILL_FINISH) {
                 setViewState(ViewState.DROP_IN_FINISHING);
+            }
+        });
+
+        dropInViewModel.getUserCanceledError().observe(getViewLifecycleOwner(), exception -> {
+            if(exception instanceof UserCanceledException){
+                setViewState(ViewState.SHOW_PAYMENT_METHODS);
             }
         });
 

--- a/Drop-In/src/main/res/layout/bt_fragment_bottom_sheet.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_bottom_sheet.xml
@@ -17,17 +17,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/back_button"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/view_pager"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:alpha="0"
-        />
-
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"

--- a/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
@@ -13,6 +13,27 @@
         android:animateLayoutChanges="true"
         android:orientation="vertical">
 
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <Button
+                android:id="@+id/bt_cancel_button"
+                style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/bt_cancel"
+                android:theme="@style/bt_edit_button" />
+
+            <TextView
+                android:id="@+id/bt_select_payment_method_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="@string/bt_select_payment_method" />
+
+        </RelativeLayout>
+
         <LinearLayout
             android:id="@+id/bt_vaulted_payment_methods_wrapper"
             android:layout_width="wrap_content"

--- a/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
@@ -11,115 +11,116 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
-        android:orientation="vertical">
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:orientation="vertical" >
 
-        <Button
-            android:id="@+id/bt_cancel_button"
-            style="@style/Widget.AppCompat.Button.Borderless.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/bt_cancel"
-            android:theme="@style/bt_edit_button" />
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/bt_select_payment_method_header"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/bt_select_payment_method"
-            android:theme="@style/bt_select_payment_method_title" />
-    </RelativeLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
-        android:orientation="vertical">
-
-        <LinearLayout
-            android:id="@+id/bt_vaulted_payment_methods_wrapper"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone">
-
-            <RelativeLayout
+            <Button
+                android:id="@+id/bt_cancel_button"
+                style="@style/Widget.AppCompat.Button.Borderless.Colored"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingTop="@dimen/bt_choose_existing_payment_label_padding_top">
+                android:text="@string/bt_cancel"
+                android:theme="@style/bt_edit_button" />
 
-                <Button
-                    android:id="@+id/bt_vault_edit_button"
-                    style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            <TextView
+                android:id="@+id/bt_select_payment_method_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="@string/bt_select_payment_method"
+                android:theme="@style/bt_select_payment_method_title" />
+        </RelativeLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/bt_vaulted_payment_methods_wrapper"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <RelativeLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:text="@string/bt_edit"
-                    android:theme="@style/bt_edit_button"
-                    android:visibility="invisible" />
+                    android:paddingTop="@dimen/bt_choose_existing_payment_label_padding_top">
 
-                <TextView
-                    android:id="@+id/bt_vaulted_payment_methods_header"
-                    style="@style/bt_choose_payment_label"
-                    android:layout_width="wrap_content"
+                    <Button
+                        android:id="@+id/bt_vault_edit_button"
+                        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:text="@string/bt_edit"
+                        android:theme="@style/bt_edit_button"
+                        android:visibility="invisible" />
+
+                    <TextView
+                        android:id="@+id/bt_vaulted_payment_methods_header"
+                        style="@style/bt_choose_payment_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignTop="@id/bt_vault_edit_button"
+                        android:layout_alignBottom="@id/bt_vault_edit_button"
+                        android:layout_alignParentStart="true"
+                        android:layout_marginStart="20dp"
+                        android:gravity="center_vertical"
+                        android:text="@string/bt_recent" />
+
+                </RelativeLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/bt_vaulted_payment_methods"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignTop="@id/bt_vault_edit_button"
-                    android:layout_alignBottom="@id/bt_vault_edit_button"
-                    android:layout_alignParentStart="true"
-                    android:layout_marginStart="20dp"
-                    android:gravity="center_vertical"
-                    android:text="@string/bt_recent" />
+                    android:paddingLeft="4dp"
+                    android:paddingRight="4dp" />
 
-            </RelativeLayout>
+                <include layout="@layout/bt_section_divider" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/bt_supported_payment_methods_header"
+                style="@style/bt_choose_payment_label"
+                android:paddingTop="@dimen/bt_choose_new_payment_label_padding_top"
+                android:paddingBottom="@dimen/bt_payment_label_padding_bottom"
+                android:text="@string/bt_other"
+                android:visibility="gone"
+                />
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/bt_vaulted_payment_methods"
+                android:id="@+id/bt_supported_payment_methods"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingLeft="4dp"
                 android:paddingRight="4dp" />
 
-            <include layout="@layout/bt_section_divider" />
-
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/bt_supported_payment_methods_header"
-            style="@style/bt_choose_payment_label"
-            android:paddingTop="@dimen/bt_choose_new_payment_label_padding_top"
-            android:paddingBottom="@dimen/bt_payment_label_padding_bottom"
-            android:text="@string/bt_other"
-            android:visibility="gone"
-            />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/bt_supported_payment_methods"
+        <RelativeLayout
+            android:id="@+id/bt_select_payment_method_loader_wrapper"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="4dp"
-            android:paddingRight="4dp" />
+            android:layout_height="match_parent"
+            android:background="@color/bt_base_background"
+            android:orientation="vertical">
 
-    </LinearLayout>
+            <ProgressBar
+                android:id="@+id/bt_select_payment_method_loader"
+                android:layout_width="@dimen/bt_progress_bar_diameter"
+                android:layout_height="@dimen/bt_progress_bar_diameter"
+                android:layout_centerInParent="true"
+                android:indeterminate="true" />
 
-    <RelativeLayout
-        android:id="@+id/bt_select_payment_method_loader_wrapper"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/bt_base_background"
-        android:gravity="center"
-        android:orientation="vertical">
+        </RelativeLayout>
 
-        <ProgressBar
-            android:id="@+id/bt_select_payment_method_loader"
-            android:layout_width="@dimen/bt_progress_bar_diameter"
-            android:layout_height="@dimen/bt_progress_bar_diameter"
-            android:layout_centerInParent="true"
-            android:indeterminate="true" />
-
-    </RelativeLayout>
     </LinearLayout>
 
 </FrameLayout>

--- a/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
-        android:orientation="vertical" >
+        android:orientation="vertical"
+        android:contentDescription="@string/bt_select_payment_method" >
 
         <RelativeLayout
             android:layout_width="match_parent"

--- a/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_supported_payment_methods.xml
@@ -12,27 +12,32 @@
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
         android:orientation="vertical">
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        <Button
+            android:id="@+id/bt_cancel_button"
+            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bt_cancel"
+            android:theme="@style/bt_edit_button" />
 
-            <Button
-                android:id="@+id/bt_cancel_button"
-                style="@style/Widget.AppCompat.Button.Borderless.Colored"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/bt_cancel"
-                android:theme="@style/bt_edit_button" />
+        <TextView
+            android:id="@+id/bt_select_payment_method_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/bt_select_payment_method"
+            android:theme="@style/bt_select_payment_method_title" />
+    </RelativeLayout>
 
-            <TextView
-                android:id="@+id/bt_select_payment_method_header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:text="@string/bt_select_payment_method" />
-
-        </RelativeLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:orientation="vertical">
 
         <LinearLayout
             android:id="@+id/bt_vaulted_payment_methods_wrapper"
@@ -86,7 +91,9 @@
             style="@style/bt_choose_payment_label"
             android:paddingTop="@dimen/bt_choose_new_payment_label_padding_top"
             android:paddingBottom="@dimen/bt_payment_label_padding_bottom"
-            android:text="@string/bt_select_payment_method" />
+            android:text="@string/bt_other"
+            android:visibility="gone"
+            />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/bt_supported_payment_methods"
@@ -97,7 +104,7 @@
 
     </LinearLayout>
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/bt_select_payment_method_loader_wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -109,9 +116,10 @@
             android:id="@+id/bt_select_payment_method_loader"
             android:layout_width="@dimen/bt_progress_bar_diameter"
             android:layout_height="@dimen/bt_progress_bar_diameter"
-            android:layout_gravity="center"
+            android:layout_centerInParent="true"
             android:indeterminate="true" />
 
+    </RelativeLayout>
     </LinearLayout>
 
 </FrameLayout>

--- a/Drop-In/src/main/res/values/styles.xml
+++ b/Drop-In/src/main/res/values/styles.xml
@@ -86,6 +86,15 @@
         <item name="android:textColor">@color/bt_black_87</item>
     </style>
 
+    <style name="bt_select_payment_method_title">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:textSize">17sp</item>
+        <item name="android:textColor">@color/bt_black_87</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="bt_edit_button" parent="Theme.AppCompat.Light">
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Borderless.Colored</item>
         <item name="colorControlHighlight">@color/bt_color_highlight</item>

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityTest.kt
@@ -17,6 +17,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.android.controller.ActivityController
 import java.util.*
+import kotlin.collections.ArrayList
 
 @RunWith(RobolectricTestRunner::class)
 class DropInActivityTest {
@@ -115,6 +116,8 @@ class DropInActivityTest {
         val error = UserCanceledException("User canceled 3DS.")
         val dropInClient = MockDropInClientBuilder()
             .deliverBrowseSwitchResultError(error)
+            .getSupportedPaymentMethodsSuccess(ArrayList())
+            .getVaultedPaymentMethodsSuccess(ArrayList())
             .build()
 
         setupDropInActivity(dropInClient, dropInRequest)
@@ -284,7 +287,7 @@ class DropInActivityTest {
     }
 
     @Test
-    fun onVaultedPaymentMethodSelectedEvent_when3DSFails_reloadsPaymentMethodsAndFinishes() {
+    fun onVaultedPaymentMethodSelectedEvent_when3DSFails_Finishes() {
         authorization = Authorization.fromString(UnitTestFixturesHelper.base64EncodedClientTokenFromFixture(Fixtures.CLIENT_TOKEN))
         val error = Exception("three d secure failure")
         val dropInClient = MockDropInClientBuilder()
@@ -305,7 +308,6 @@ class DropInActivityTest {
         val cardNonce = CardNonce.fromJSON(JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE))
         activity.supportFragmentManager.setFragmentResult(DropInEvent.REQUEST_KEY, DropInEvent.createVaultedPaymentMethodSelectedEvent(cardNonce).toBundle())
 
-        verify(dropInClient).getVaultedPaymentMethods(same(activity), any(GetPaymentMethodNoncesCallback::class.java))
         assertEquals(RESULT_FIRST_USER, shadowActivity.resultCode)
         assertEquals(error, shadowActivity.resultIntent.getSerializableExtra(DropInResult.EXTRA_ERROR))
         assertTrue(activity.isFinishing)
@@ -679,7 +681,7 @@ class DropInActivityTest {
         val error = Exception("error")
         val dropInClient = MockDropInClientBuilder()
             .authorization(authorization)
-            .getSupportedPaymentMethodsError(error)
+            .getSupportedCardTypesError(error)
             .build()
         setupDropInActivity(dropInClient, dropInRequest)
         val shadowActivity = shadowOf(activity)


### PR DESCRIPTION
### Summary of changes

 - Add header to Drop-in with Cancel button (aligns with iOS)
 - Remove cancel button from background view
 - Fetch vaulted payment methods and supported payment methods before displaying drop-in sheet to avoid unexpected UI changes when vaulted payment methods are loaded.
 - Show loading indicator, header, and cancel button while fetching vaulted/supported payment methods

**Before**
![Screen Shot 2021-11-03 at 11 43 24 AM](https://user-images.githubusercontent.com/67924275/140115130-a0c316af-f1d8-4bf0-b1e9-acae317370b1.png)
![Screen Shot 2021-11-03 at 11 43 36 AM](https://user-images.githubusercontent.com/67924275/140115246-1f6b637f-a388-4cf7-8f5d-d3b37b024a8f.png)

**After**
![Screen Shot 2021-11-03 at 11 42 48 AM](https://user-images.githubusercontent.com/67924275/140114904-eb02cf66-2595-4d42-a557-89ed4284ddcd.png)
![Screen Shot 2021-11-03 at 11 42 14 AM](https://user-images.githubusercontent.com/67924275/140115418-a3ef5705-3bca-481c-825b-2171e3f7f8fa.png)


 ### Checklist

 - ~[ ] Added a changelog entry~ (These accessibility fixes aren't tied to any GH issues - should there be a CHANGELOG for this?)

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
- @sarahkoop 
