### PR TITLE
Hide loading indicated after user canceled 3DS flow from vaulted Card

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11.0.10'
-          distribution: 'zulu'
+          java-version: '11'
+          distribution: 'temurin'
       - name: Unit Tests
         run: ./gradlew --stacktrace testRelease

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '11.0.10'
           distribution: 'zulu'
       - name: Unit Tests
         run: ./gradlew --stacktrace testRelease

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'temurin'
+          distribution: 'zulu'
       - name: Unit Tests
         run: ./gradlew --stacktrace testRelease

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -267,6 +267,25 @@ class SupportedPaymentMethodsFragmentUITest {
     }
 
     @Test
+    fun whenStateIsRESUMED_userCanceledErrorPresentInViewModel_hidesLoader() {
+        dropInRequest.isVaultManagerEnabled = false
+        val bundle = bundleOf("EXTRA_DROP_IN_REQUEST" to dropInRequest)
+
+        val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onView(withId(R.id.bt_select_payment_method_loader_wrapper)).check(matches(isDisplayed()))
+
+        scenario.onFragment { fragment ->
+            fragment.dropInViewModel.setSupportedPaymentMethods(supportedPaymentMethods)
+            fragment.dropInViewModel.setUserCanceledError(UserCanceledException("User canceled 3DS."))
+        }
+
+        onView(withId(R.id.bt_select_payment_method_loader_wrapper)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.bt_supported_payment_methods)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    @Test
     fun whenStateIsRESUMED_whenHasSupportedPaymentMethods_hidesLoader() {
         dropInRequest.isVaultManagerEnabled = true
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -111,6 +111,12 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
             }
         });
 
+        dropInViewModel.getUserCanceledError().observe(getViewLifecycleOwner(), exception -> {
+            if (exception instanceof UserCanceledException && hasSupportedPaymentMethods()) {
+                setViewState(ViewState.SHOW_PAYMENT_METHODS);
+            }
+        });
+
         vaultManagerButton.setOnClickListener(v -> sendDropInEvent(new DropInEvent(DropInEventType.SHOW_VAULT_MANAGER)));
 
         sendAnalyticsEvent("appeared");


### PR DESCRIPTION
### Summary of changes

 - Fixes issue where the loading indicator would be shown and never hidden if a user canceled the 3ds flow from a vaulted card.

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @jplukarski 
