### PR TITLE
Update CardForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Bump braintree_android module dependency versions to `4.7.0`
+* Bump `card-form` to `5.3.0` 
 * Venmo
   * Add `VenmoRequest` setter to `DropInRequest`
   * Don't show Venmo payment method option when Venmo not installed on device

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     api 'com.braintreepayments.api:data-collector:4.7.0'
     api 'com.braintreepayments.api:union-pay:4.7.0'
 
-    api 'com.braintreepayments:card-form:5.2.0'
+    api 'com.braintreepayments:card-form:5.3.0'
 
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.braintreepayments.api.dropin.R;
 import com.braintreepayments.cardform.OnCardFormSubmitListener;
 import com.braintreepayments.cardform.utils.CardType;
+import com.braintreepayments.cardform.view.AccessibleSupportedCardTypesView;
 import com.braintreepayments.cardform.view.CardEditText;
 import com.braintreepayments.cardform.view.CardForm;
 import com.braintreepayments.cardform.view.SupportedCardTypesView;
@@ -24,7 +25,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     @VisibleForTesting
     CardForm cardForm;
 
-    private SupportedCardTypesView supportedCardTypesView;
+    private AccessibleSupportedCardTypesView supportedCardTypesView;
     private AnimatedButtonView animatedButtonView;
 
     @VisibleForTesting

--- a/Drop-In/src/main/res/layout/bt_fragment_add_card.xml
+++ b/Drop-In/src/main/res/layout/bt_fragment_add_card.xml
@@ -31,14 +31,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <com.braintreepayments.cardform.view.SupportedCardTypesView
+            <com.braintreepayments.cardform.view.AccessibleSupportedCardTypesView
                 android:id="@+id/bt_supported_card_types"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingStart="52dp"
-                android:paddingLeft="52dp"
                 android:paddingTop="36dp"
-                android:paddingEnd="0dp"
                 tools:ignore="RtlCompat" />
 
             <com.braintreepayments.api.AnimatedButtonView


### PR DESCRIPTION
### Summary of changes

 - Bump card-form to 5.3.0
 - Use AccessibleSupportedCardTypesView instead of SupportedCardTypesView - makes supported card types accessible via tab navigation
 
**Old**
![Screen Shot 2021-11-01 at 1 33 48 PM](https://user-images.githubusercontent.com/67924275/140972993-7927791a-618b-4e4d-8115-0c1d112d5331.png)

**New**
![Screen Shot 2021-11-09 at 11 19 07 AM](https://user-images.githubusercontent.com/67924275/140973008-6435c50f-57a6-43ed-bb96-bd9b27a54574.png)

**Note:** We are missing a string translation for a content description for the supported card types (we'd like the screen reader to say that the list is "Supported card types". Currently, each icon has a description, but the list as a whole is missing one. We think this is ok to PR and we will add the content description when we can get a translation.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
- @sarahkoop 
