### PR TITLE
Update launchMode to singleTask

### DIFF
--- a/Drop-In/src/main/AndroidManifest.xml
+++ b/Drop-In/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 
         <activity android:name="com.braintreepayments.api.DropInActivity"
             android:theme="@style/bt_drop_in_activity_theme"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
### Summary of changes

 - Update `launchMode` of `DropInActivity` to `singleTask`

While testing on older Android API versions (21-23) we discovered that the browser switching payment flows were crashing on return because a new instance of the `DropInActivity` was being created, rather than calling `onNewIntent` in the original `DropInActivity` instance (required for handling the browser switch result). To resolve this, we are updating the launchMode of `DropInActivity` to `singleTask`. This launchMode only allows for a single instance of the `DropInActivity` to exist in the system. With this change, in lower Android API versions, the browser switch is behaving as expected (i.e. the `onNewIntent` method is being called in the single original instance of `DropInActivity` and the browser switch results are being handled correctly). See [Android launchMode](https://developer.android.com/guide/topics/manifest/activity-element#lmode) for more information. 

 ### Checklist

 - ~[] Added a changelog entry~

### Authors

- @sshropshire 
- @sarahkoop 
