### PR TITLE
Bump Braintree Core to 4.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android module dependency versions to `4.8.1`
+
 ## 6.0.1
 
 * Check if `BottomSheetPresenter` is null before unbinding in `BottomSheetFragment` (fixes #319)

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -68,14 +68,14 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.fragment:fragment:1.3.5'
 
-    api 'com.braintreepayments.api:braintree-core:4.7.0'
-    api 'com.braintreepayments.api:three-d-secure:4.7.0'
-    api 'com.braintreepayments.api:paypal:4.7.0'
-    api 'com.braintreepayments.api:venmo:4.7.0'
-    api 'com.braintreepayments.api:google-pay:4.7.0'
-    api 'com.braintreepayments.api:card:4.7.0'
-    api 'com.braintreepayments.api:data-collector:4.7.0'
-    api 'com.braintreepayments.api:union-pay:4.7.0'
+    api 'com.braintreepayments.api:braintree-core:4.8.1'
+    api 'com.braintreepayments.api:three-d-secure:4.8.1'
+    api 'com.braintreepayments.api:paypal:4.8.1'
+    api 'com.braintreepayments.api:venmo:4.8.1'
+    api 'com.braintreepayments.api:google-pay:4.8.1'
+    api 'com.braintreepayments.api:card:4.8.1'
+    api 'com.braintreepayments.api:data-collector:4.8.1'
+    api 'com.braintreepayments.api:union-pay:4.8.1'
 
     api 'com.braintreepayments:card-form:5.3.0'
 
@@ -96,6 +96,7 @@ dependencies {
     testImplementation "androidx.core:core-ktx:1.6.0"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10"
     testImplementation "androidx.test:core:1.4.0"
+    testImplementation 'androidx.work:work-testing:2.5.0'
 
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.work.testing.WorkManagerTestInitHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -56,10 +57,11 @@ public class DropInClientUnitTest {
         MockitoAnnotations.initMocks(this);
 
         dropInSharedPreferences = mock(DropInSharedPreferences.class);
-
         ActivityController<FragmentActivity> activityController =
                 Robolectric.buildActivity(FragmentActivity.class);
         activity = activityController.get();
+        // This suppresses errors from WorkManager initialization within BraintreeClient initialization (AnalyticsClient)
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext());
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Bump braintree_android to `4.8.1` (fixes: #322 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @sshropshire 
