### PR TITLE
Fix issue where UserCanceledException is not being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Fix issue where `UserCanceledException` was not being sent on bottom sheet dismissal.
+
 ## 6.1.0
+
 * Update Vault Manager inline documentation 
 * Add `ClientTokenProvider` interface for asynchronously fetching client token authorization
 * Add new `DropInClient` constructors that accept `ClientTokenProvider` or tokenization key string
@@ -17,6 +22,7 @@
 * Check if `BottomSheetPresenter` is null before unbinding in `BottomSheetFragment` (fixes #319)
 
 ## 6.0.0
+
 * Bump braintree_android module dependency versions to `4.7.0`
 * Bump `card-form` to `5.3.0`
 * Localization

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivityResultContract.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivityResultContract.java
@@ -30,19 +30,22 @@ class DropInActivityResultContract extends ActivityResultContract<DropInIntentDa
 
     @Override
     public DropInResult parseResult(int resultCode, @Nullable Intent intent) {
-        if (intent != null) {
-            if (resultCode == AppCompatActivity.RESULT_OK) {
+        if (resultCode == AppCompatActivity.RESULT_OK) {
+            if (intent != null) {
                 return intent.getParcelableExtra(DropInResult.EXTRA_DROP_IN_RESULT);
-            } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
-                DropInResult userCanceledResult = new DropInResult();
-                userCanceledResult.setError(new UserCanceledException("User canceled DropIn."));
-                return userCanceledResult;
-            } else if (resultCode == AppCompatActivity.RESULT_FIRST_USER) {
+            }
+        } else if (resultCode == AppCompatActivity.RESULT_CANCELED) {
+            DropInResult userCanceledResult = new DropInResult();
+            userCanceledResult.setError(new UserCanceledException("User canceled DropIn."));
+            return userCanceledResult;
+        } else if (resultCode == AppCompatActivity.RESULT_FIRST_USER) {
+            if (intent != null) {
                 DropInResult errorResult = new DropInResult();
                 errorResult.setError((Exception) intent.getSerializableExtra(EXTRA_ERROR));
                 return errorResult;
             }
         }
+
         return null;
     }
 }

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityResultContractUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityResultContractUnitTest.java
@@ -71,7 +71,7 @@ public class DropInActivityResultContractUnitTest {
     public void parseResult_whenResultIsCANCELED_returnsDropInResultWithUserCanceledError() {
         DropInActivityResultContract sut = new DropInActivityResultContract();
 
-        DropInResult dropInResult = sut.parseResult(RESULT_CANCELED, new Intent());
+        DropInResult dropInResult = sut.parseResult(RESULT_CANCELED, null);
 
         assertNotNull(dropInResult);
         UserCanceledException error = (UserCanceledException) dropInResult.getError();


### PR DESCRIPTION
### Summary of changes

 - Fixes #346
 - This PR fixes an issue where `UserCanceledException` was not being sent properly.

 ### Checklist

 - [x] Added a changelog entry
