### PR TITLE
Bump braintree android core version and update error parsing logic to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Bump braintree_android module dependency versions to `4.15.0`
 * Notify merchant via error message the payment method is duplicated (fixes #357)
 
 ## 6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Notify merchant via error message the payment method is duplicated (fixes #357)
+
 ## 6.3.0
 
 * Deprecate constructors that require a `DropInRequest`.

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -73,14 +73,14 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.4.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
 
-    api 'com.braintreepayments.api:braintree-core:4.12.0'
-    api 'com.braintreepayments.api:three-d-secure:4.12.0'
-    api 'com.braintreepayments.api:paypal:4.12.0'
-    api 'com.braintreepayments.api:venmo:4.12.0'
-    api 'com.braintreepayments.api:google-pay:4.12.0'
-    api 'com.braintreepayments.api:card:4.12.0'
-    api 'com.braintreepayments.api:data-collector:4.12.0'
-    api 'com.braintreepayments.api:union-pay:4.12.0'
+    api 'com.braintreepayments.api:braintree-core:4.15.0'
+    api 'com.braintreepayments.api:three-d-secure:4.15.0'
+    api 'com.braintreepayments.api:paypal:4.15.0'
+    api 'com.braintreepayments.api:venmo:4.15.0'
+    api 'com.braintreepayments.api:google-pay:4.15.0'
+    api 'com.braintreepayments.api:card:4.15.0'
+    api 'com.braintreepayments.api:data-collector:4.15.0'
+    api 'com.braintreepayments.api:union-pay:4.15.0'
 
     api 'com.braintreepayments:card-form:5.4.0'
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -50,7 +50,8 @@ class AddCardFragmentUITest {
 
         scenario.onFragment { fragment ->
             fragment.dropInViewModel.setSupportedCardTypes(listOf(CardType.VISA))
-            fragment.dropInViewModel.setCardTokenizationError(ErrorWithResponse.fromJson(Fixtures.CREDIT_CARD_EXPIRATION_ERROR_RESPONSE))
+            fragment.dropInViewModel.setCardTokenizationError(
+                    ErrorWithResponse.fromJson(IntegrationTestFixtures.CREDIT_CARD_EXPIRATION_ERROR_RESPONSE))
 
             assertNull(fragment.cardForm.cardEditText.textInputLayoutParent?.error)
         }
@@ -151,9 +152,25 @@ class AddCardFragmentUITest {
 
         scenario.onFragment { fragment ->
             fragment.dropInViewModel.setSupportedCardTypes(listOf(CardType.VISA))
-            fragment.dropInViewModel.setCardTokenizationError(ErrorWithResponse.fromJson(Fixtures.CREDIT_CARD_ERROR_RESPONSE))
+            fragment.dropInViewModel.setCardTokenizationError(
+                    ErrorWithResponse.fromJson(IntegrationTestFixtures.CREDIT_CARD_ERROR_RESPONSE))
 
             assertEquals(fragment.context?.getString(R.string.bt_card_number_invalid),
+                    fragment.cardForm.cardEditText.textInputLayoutParent?.error)
+        }
+    }
+
+    @Test
+    fun whenStateIsRESUMED_whenCardNumberIsDuplicate_displaysErrorsInlineToUser() {
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        scenario.onFragment { fragment ->
+            fragment.dropInViewModel.setSupportedCardTypes(listOf(CardType.VISA))
+            fragment.dropInViewModel.setCardTokenizationError(
+                    ErrorWithResponse.fromJson(IntegrationTestFixtures.ERRORS_CREDIT_CARD_DUPLICATE))
+
+            assertEquals(fragment.context?.getString(R.string.bt_card_already_exists),
                     fragment.cardForm.cardEditText.textInputLayoutParent?.error)
         }
     }
@@ -165,7 +182,8 @@ class AddCardFragmentUITest {
 
         scenario.onFragment { fragment ->
             fragment.dropInViewModel.setSupportedCardTypes(listOf(CardType.VISA))
-            fragment.dropInViewModel.setCardTokenizationError(ErrorWithResponse.fromJson(Fixtures.CREDIT_CARD_ERROR_RESPONSE))
+            fragment.dropInViewModel.setCardTokenizationError(
+                    ErrorWithResponse.fromJson(IntegrationTestFixtures.CREDIT_CARD_ERROR_RESPONSE))
         }
 
         onView(withId(R.id.bt_button)).check(matches(isDisplayed()))

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/CardDetailsFragmentUITest.kt
@@ -448,7 +448,8 @@ class CardDetailsFragmentUITest {
             scenario.moveToState(Lifecycle.State.RESUMED)
 
             scenario.onFragment { fragment ->
-                fragment.dropInViewModel.setCardTokenizationError(ErrorWithResponse.fromJson(Fixtures.CREDIT_CARD_NON_NUMBER_ERROR_RESPONSE))
+                fragment.dropInViewModel.setCardTokenizationError(
+                        ErrorWithResponse.fromJson(IntegrationTestFixtures.CREDIT_CARD_NON_NUMBER_ERROR_RESPONSE))
 
                 assertEquals(fragment.context?.getString(R.string.bt_expiration_invalid),
                         fragment.cardForm.expirationDateEditText.textInputLayoutParent?.error)

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/IntegrationTestFixtures.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/IntegrationTestFixtures.kt
@@ -1,0 +1,93 @@
+package com.braintreepayments.api
+
+object IntegrationTestFixtures {
+
+    // language=JSON
+    const val CREDIT_CARD_ERROR_RESPONSE = """
+        {
+          "error": {
+            "message": "Credit card is invalid"
+          },
+          "fieldErrors": [
+            {
+              "field": "creditCard",
+              "fieldErrors": [
+                {
+                  "field": "billingAddress",
+                  "message": "Postal code is invalid"
+                },
+                {
+                  "field": "cvv",
+                  "message": "CVV is invalid"
+                },
+                {
+                  "field": "expirationMonth",
+                  "message": "Expiration month is invalid"
+                },
+                {
+                  "field": "expirationYear",
+                  "message": "Expiration year is invalid"
+                },
+                {
+                  "field": "number",
+                  "message": "Credit card number is required"
+                },
+                {
+                  "field": "base",
+                  "message": "Credit card must include number, payment_method_nonce, or venmo_sdk_payment_method_code"
+                }
+              ]
+            }
+          ]
+        }
+    """
+
+    // language=JSON
+    const val ERRORS_CREDIT_CARD_DUPLICATE = """
+        {
+            "error": {
+                "message": "Credit card is invalid"
+            },
+            "fieldErrors": [
+                {
+                    "field": "creditCard",
+                    "fieldErrors": [
+                        {
+                            "field": "number",
+                            "message": "Duplicate card exists in the vault.",
+                            "code": "81724"
+                        }
+                    ]
+                }
+            ]
+        }
+    """
+
+    // language=JSON
+    const val CREDIT_CARD_EXPIRATION_ERROR_RESPONSE = """
+        {
+          "error": {
+            "message": "Credit card is invalid"
+          },
+          "fieldErrors": [
+            {
+              "field": "creditCard",
+              "fieldErrors": [
+                {
+                  "field": "expirationMonth",
+                  "message": "Expiration month is invalid"
+                },
+                {
+                  "field": "expirationYear",
+                  "message": "Expiration year is invalid"
+                },
+                {
+                  "field": "base",
+                  "message": "Credit card must include number, payment_method_nonce, or venmo_sdk_payment_method_code"
+                }
+              ]
+            }
+          ]
+        }
+    """
+}

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/IntegrationTestFixtures.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/IntegrationTestFixtures.kt
@@ -64,6 +64,42 @@ object IntegrationTestFixtures {
     """
 
     // language=JSON
+    const val CREDIT_CARD_NON_NUMBER_ERROR_RESPONSE = """
+        {
+          "error": {
+            "message": "Credit card is invalid"
+          },
+          "fieldErrors": [
+            {
+              "field": "creditCard",
+              "fieldErrors": [
+                {
+                  "field": "billingAddress",
+                  "message": "Postal code is invalid"
+                },
+                {
+                  "field": "cvv",
+                  "message": "CVV is invalid"
+                },
+                {
+                  "field": "expirationMonth",
+                  "message": "Expiration month is invalid"
+                },
+                {
+                  "field": "expirationYear",
+                  "message": "Expiration year is invalid"
+                },
+                {
+                  "field": "base",
+                  "message": "Credit card must include number, payment_method_nonce, or venmo_sdk_payment_method_code"
+                }
+              ]
+            }
+          ]
+        }
+    """
+
+    // language=JSON
     const val CREDIT_CARD_EXPIRATION_ERROR_RESPONSE = """
         {
           "error": {
@@ -88,6 +124,84 @@ object IntegrationTestFixtures {
               ]
             }
           ]
+        }
+    """
+
+    // language=JSON
+    const val VISA_CREDIT_CARD_RESPONSE = """
+        {
+          "creditCards": [
+            {
+              "type": "CreditCard",
+              "nonce": "123456-12345-12345-a-adfa",
+              "description": "ending in ••11",
+              "default": false,
+              "isLocked": false,
+              "securityQuestions": [],
+              "details":
+              {
+                "cardType": "Visa",
+                "lastTwo": "11",
+                "lastFour": "1111"
+              }
+            }
+          ]
+        }
+    """
+
+    // language=JSON
+    const val PAYMENT_METHODS_VISA_CREDIT_CARD = """
+        {
+          "type": "CreditCard",
+          "nonce": "12345678-1234-1234-1234-123456789012",
+          "description": "ending in ••11",
+          "default": false,
+          "isLocked": false,
+          "securityQuestions": [],
+          "details":
+          {
+            "cardType": "Visa",
+            "lastTwo": "11",
+            "lastFour": "1111"
+          }
+        }
+    """
+
+    // language=JSON
+    const val PAYPAL_ACCOUNT_JSON = """
+        {
+          "paypalAccounts": [
+            {
+              "type": "PayPalAccount",
+              "nonce": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+              "description": "with email paypalaccount@example.com",
+              "default": false,
+              "isLocked": false,
+              "securityQuestions": [],
+              "details": {
+                "email": "paypalaccount@example.com",
+                "payerInfo": {
+                }
+              }
+            }
+          ]
+        }
+    """
+
+    // language=JSON
+    const val PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE = """
+        {
+          "venmoAccounts": [{
+            "type": "VenmoAccount",
+            "nonce": "fake-venmo-nonce",
+            "description": "VenmoAccount",
+            "consumed": false,
+            "default": true,
+            "details": {
+              "cardType": "Discover",
+              "username": "venmojoe"
+            }
+          }]
         }
     """
 }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/SupportedPaymentMethodsFragmentUITest.kt
@@ -31,7 +31,7 @@ class SupportedPaymentMethodsFragmentUITest {
             DropInPaymentMethod.GOOGLE_PAY
     )
 
-    private val vaultedPaymentMethods = listOf(CardNonce.fromJSON(JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE)))
+    private val vaultedPaymentMethods = listOf(CardNonce.fromJSON(JSONObject(IntegrationTestFixtures.VISA_CREDIT_CARD_RESPONSE)))
 
     private lateinit var dropInRequest: DropInRequest
 
@@ -128,9 +128,9 @@ class SupportedPaymentMethodsFragmentUITest {
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
-        val cardNonce = CardNonce.fromJSON(JSONObject(Fixtures.PAYMENT_METHODS_VISA_CREDIT_CARD))
-        val payPalNonce = PayPalAccountNonce.fromJSON(JSONObject(Fixtures.PAYPAL_ACCOUNT_JSON))
-        val venmoAccountNonce = VenmoAccountNonce.fromJSON(JSONObject(Fixtures.PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE))
+        val cardNonce = CardNonce.fromJSON(JSONObject(IntegrationTestFixtures.PAYMENT_METHODS_VISA_CREDIT_CARD))
+        val payPalNonce = PayPalAccountNonce.fromJSON(JSONObject(IntegrationTestFixtures.PAYPAL_ACCOUNT_JSON))
+        val venmoAccountNonce = VenmoAccountNonce.fromJSON(JSONObject(IntegrationTestFixtures.PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE))
 
         val vaultedPaymentMethods = listOf(cardNonce, payPalNonce, venmoAccountNonce)
 
@@ -170,7 +170,7 @@ class SupportedPaymentMethodsFragmentUITest {
         val scenario = FragmentScenario.launchInContainer(SupportedPaymentMethodsFragment::class.java, bundle)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
-        val cardNonce = CardNonce.fromJSON(JSONObject(Fixtures.PAYMENT_METHODS_VISA_CREDIT_CARD))
+        val cardNonce = CardNonce.fromJSON(JSONObject(IntegrationTestFixtures.PAYMENT_METHODS_VISA_CREDIT_CARD))
         val vaultedPaymentMethods = listOf(cardNonce)
 
         scenario.onFragment { fragment ->

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/VaultManagerFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/VaultManagerFragmentUITest.kt
@@ -26,7 +26,7 @@ class VaultManagerFragmentUITest {
 
     @Before
     fun beforeEach() {
-        cardNonce = CardNonce.fromJSON(JSONObject(Fixtures.VISA_CREDIT_CARD_RESPONSE))
+        cardNonce = CardNonce.fromJSON(JSONObject(IntegrationTestFixtures.VISA_CREDIT_CARD_RESPONSE))
         vaultedPaymentMethodNonces.add(cardNonce)
 
         scenario = FragmentScenario.launchInContainer(VaultManagerFragment::class.java)

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -131,7 +131,7 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     void setErrors(ErrorWithResponse errors) {
         boolean isDuplicatePaymentMethod = braintreeErrorInspector.isDuplicatePaymentError(errors);
         if (isDuplicatePaymentMethod) {
-            cardForm.setCardNumberError("This credit card already exists as a saved payment method.");
+            cardForm.setCardNumberError(getString(R.string.bt_card_already_exists));
         } else {
             BraintreeError formErrors = errors.errorFor("creditCard");
             if (formErrors != null) {

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -31,6 +31,8 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     @VisibleForTesting
     DropInViewModel dropInViewModel;
 
+    BraintreeErrorInspector braintreeErrorInspector = new BraintreeErrorInspector();
+
     static AddCardFragment from(DropInRequest dropInRequest, @Nullable String cardNumber) {
         Bundle args = new Bundle();
         args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest);
@@ -127,14 +129,17 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     }
 
     void setErrors(ErrorWithResponse errors) {
-        BraintreeError formErrors = errors.errorFor("creditCard");
-
-        if (formErrors != null) {
-            if (formErrors.errorFor("number") != null) {
-                cardForm.setCardNumberError(requireContext().getString(R.string.bt_card_number_invalid));
+        boolean isDuplicatePaymentMethod = braintreeErrorInspector.isDuplicatePaymentError(errors);
+        if (isDuplicatePaymentMethod) {
+            cardForm.setCardNumberError("This credit card already exists as a saved payment method.");
+        } else {
+            BraintreeError formErrors = errors.errorFor("creditCard");
+            if (formErrors != null) {
+                if (formErrors.errorFor("number") != null) {
+                    cardForm.setCardNumberError(requireContext().getString(R.string.bt_card_number_invalid));
+                }
             }
         }
-
         animatedButtonView.showButton();
     }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/BraintreeErrorInspector.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/BraintreeErrorInspector.java
@@ -1,0 +1,17 @@
+package com.braintreepayments.api;
+
+class BraintreeErrorInspector {
+
+    private static final int ERROR_CODE_DUPLICATE_PAYMENT = 81724;
+
+    boolean isDuplicatePaymentError(ErrorWithResponse error) {
+        BraintreeError creditCardError = error.errorFor("creditCard");
+        if (creditCardError != null) {
+            BraintreeError numberError = creditCardError.errorFor("number");
+            if (numberError != null) {
+                return (numberError.getCode() == ERROR_CODE_DUPLICATE_PAYMENT);
+            }
+        }
+        return false;
+    }
+}

--- a/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/CardDetailsFragment.java
@@ -130,7 +130,7 @@ public class CardDetailsFragment extends DropInFragment implements OnCardFormSub
     void setErrors(ErrorWithResponse errors) {
         boolean isDuplicatePaymentMethod = braintreeErrorInspector.isDuplicatePaymentError(errors);
         if (isDuplicatePaymentMethod) {
-            cardForm.setCardNumberError("This credit card already exists as a saved payment method.");
+            cardForm.setCardNumberError(getString(R.string.bt_card_already_exists));
         } else {
             BraintreeError formErrors = errors.errorFor("unionPayEnrollment");
             if (formErrors == null) {

--- a/Drop-In/src/main/res/values-ar/strings.xml
+++ b/Drop-In/src/main/res/values-ar/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">رمز الرسالة النصية</string>
     <string name="bt_sms_code_required">رمز الرسالة النصية مطلوب</string>
     <string name="bt_use_a_different_phone_number">استخدم رقم هاتف مختلفاً</string>
-    <string name="bt_sms_code_sent_to">أدخل رمز الرسالة النصية المرسل إلى %s</string>
+    <string name="bt_sms_code_sent_to">أدخل رمز الرسالة النصية المرسل إلى %1$s</string>
     <string name="bt_card_details">بيانات البطاقة</string>
     <string name="bt_confirm_enrollment">تأكيد التسجيل</string>
     <string name="bt_postal_code_invalid">الرمز البريدي غير صحيح</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">وسائل الدفع المحفوظة</string>
     <string name="bt_supported_payments">وسائل الدفع المدعومة</string>
     <string name="bt_edit_button_description">تحرير وسائل الدفع المحفوظة</string>
+    <string name="bt_card_already_exists">هذه البطاقة الائتمانية محفوظة وسيلة للدفع.</string>
 </resources>

--- a/Drop-In/src/main/res/values-cs/strings.xml
+++ b/Drop-In/src/main/res/values-cs/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Kód SMS</string>
     <string name="bt_sms_code_required">Je požadován kód SMS.</string>
     <string name="bt_use_a_different_phone_number">Použít jiné telefonní číslo</string>
-    <string name="bt_sms_code_sent_to">Zadejte kód SMS zaslaný na číslo %s.</string>
+    <string name="bt_sms_code_sent_to">Zadejte kód SMS zaslaný na číslo %1$s.</string>
     <string name="bt_card_details">Údaje o kartě</string>
     <string name="bt_confirm_enrollment">Potvrdit registraci</string>
     <string name="bt_postal_code_invalid">PSČ není platné.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Uložené způsoby platby</string>
     <string name="bt_supported_payments">Podporované způsoby platby</string>
     <string name="bt_edit_button_description">Upravit uložené způsoby platby</string>
+    <string name="bt_card_already_exists">Tato kreditní karta je již jako způsob platby uložena.</string>
 </resources>

--- a/Drop-In/src/main/res/values-da/strings.xml
+++ b/Drop-In/src/main/res/values-da/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Sms-kode</string>
     <string name="bt_sms_code_required">Sms-kode er påkrævet.</string>
     <string name="bt_use_a_different_phone_number">Brug et andet telefonnummer</string>
-    <string name="bt_sms_code_sent_to">Indtast den sms-kode, der er blevet sendt til %s.</string>
+    <string name="bt_sms_code_sent_to">Indtast den sms-kode, der er blevet sendt til %1$s.</string>
     <string name="bt_card_details">Kortoplysninger</string>
     <string name="bt_confirm_enrollment">Bekræft tilmelding.</string>
     <string name="bt_postal_code_invalid">Postnummeret er ugyldigt.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Gemte betalingsmetoder</string>
     <string name="bt_supported_payments">Understøttede betalingsmetoder</string>
     <string name="bt_edit_button_description">Rediger gemte betalingsmetoder</string>
+    <string name="bt_card_already_exists">Dette betalingskort er allerede gemt som betalingsmetode.</string>
 </resources>

--- a/Drop-In/src/main/res/values-de/strings.xml
+++ b/Drop-In/src/main/res/values-de/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS-Code</string>
     <string name="bt_sms_code_required">SMS-Code ist erforderlich</string>
     <string name="bt_use_a_different_phone_number">Andere Nummer verwenden</string>
-    <string name="bt_sms_code_sent_to">Geben Sie den SMS-Code ein, der an %s gesendet wurde</string>
+    <string name="bt_sms_code_sent_to">Geben Sie den SMS-Code ein, der an %1$s gesendet wurde</string>
     <string name="bt_card_details">Kartendaten</string>
     <string name="bt_confirm_enrollment">Anmeldung bestätigen</string>
     <string name="bt_postal_code_invalid">Postleitzahl ist ungültig</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Gespeicherte Zahlungsquellen</string>
     <string name="bt_supported_payments">Unterstützte Zahlungsquellen</string>
     <string name="bt_edit_button_description">Gespeicherte Zahlungsquellen bearbeiten</string>
+    <string name="bt_card_already_exists">Diese Kreditkarte ist bereits als gespeicherte Zahlungsquelle vorhanden.</string>
 </resources>

--- a/Drop-In/src/main/res/values-el/strings.xml
+++ b/Drop-In/src/main/res/values-el/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Κωδικός SMS</string>
     <string name="bt_sms_code_required">Ο κωδικός SMS είναι υποχρεωτικός</string>
     <string name="bt_use_a_different_phone_number">Χρησιμοποιήστε διαφορετικό αριθμό τηλεφώνου</string>
-    <string name="bt_sms_code_sent_to">Εισαγάγετε τον κωδικό SMS που στάλθηκε στο %s</string>
+    <string name="bt_sms_code_sent_to">Εισαγάγετε τον κωδικό SMS που στάλθηκε στο %1$s</string>
     <string name="bt_card_details">Στοιχεία κάρτας</string>
     <string name="bt_confirm_enrollment">Επιβεβαίωση εγγραφής</string>
     <string name="bt_postal_code_invalid">Ο ταχυδρομικός κώδικας δεν είναι έγκυρος</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Αποθηκευμένες μέθοδοι πληρωμής</string>
     <string name="bt_supported_payments">Υποστηριζόμενες μέθοδοι πληρωμής</string>
     <string name="bt_edit_button_description">Επεξεργασία αποθηκευμένων μεθόδων πληρωμής</string>
+    <string name="bt_card_already_exists">Αυτή η πιστωτική κάρτα υπάρχει ήδη ως αποθηκευμένη μέθοδος πληρωμής.</string>
 </resources>

--- a/Drop-In/src/main/res/values-es-rXC/strings.xml
+++ b/Drop-In/src/main/res/values-es-rXC/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Código vía SMS</string>
     <string name="bt_sms_code_required">Se necesita un código vía SMS</string>
     <string name="bt_use_a_different_phone_number">Utilizar un número de teléfono diferente</string>
-    <string name="bt_sms_code_sent_to">Ingrese el código enviado vía SMS a %s</string>
+    <string name="bt_sms_code_sent_to">Ingrese el código enviado vía SMS a %1$s</string>
     <string name="bt_card_details">Información de la tarjeta</string>
     <string name="bt_confirm_enrollment">Confirmar inscripción</string>
     <string name="bt_postal_code_invalid">El código postal no es válido</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Formas de pago guardadas</string>
     <string name="bt_supported_payments">Formas de pago admitidas</string>
     <string name="bt_edit_button_description">Editar formas de pago guardadas</string>
+    <string name="bt_card_already_exists">Esta tarjeta de crédito ya existe como forma de pago guardada.</string>
 </resources>

--- a/Drop-In/src/main/res/values-es/strings.xml
+++ b/Drop-In/src/main/res/values-es/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Código SMS</string>
     <string name="bt_sms_code_required">El código SMS es obligatorio</string>
     <string name="bt_use_a_different_phone_number">Usar otro número de teléfono</string>
-    <string name="bt_sms_code_sent_to">Introduce el código SMS enviado al %s</string>
+    <string name="bt_sms_code_sent_to">Introduce el código SMS enviado al %1$s</string>
     <string name="bt_card_details">Datos de la tarjeta</string>
     <string name="bt_confirm_enrollment">Confirmar inscripción</string>
     <string name="bt_postal_code_invalid">El código postal no es válido</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Formas de pago guardadas</string>
     <string name="bt_supported_payments">Formas de pago admitidas</string>
     <string name="bt_edit_button_description">Editar formas de pago guardadas</string>
+    <string name="bt_card_already_exists">Esta tarjeta de crédito ya existe como forma de pago guardada.</string>
 </resources>

--- a/Drop-In/src/main/res/values-fi/strings.xml
+++ b/Drop-In/src/main/res/values-fi/strings.xml
@@ -4,7 +4,7 @@
     <string name="bt_descriptor_mastercard">Mastercard</string>
     <string name="bt_descriptor_amex">Amex</string>
     <string name="bt_descriptor_jcb">JCB</string>
-    <string name="bt_descriptor_discover">Löydä</string>
+    <string name="bt_descriptor_discover">Discover</string>
     <string name="bt_descriptor_diners">Diners</string>
     <string name="bt_descriptor_maestro">Maestro</string>
     <string name="bt_descriptor_paypal">PayPal</string>
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Tekstiviestikoodi</string>
     <string name="bt_sms_code_required">Tekstiviestikoodi on pakollinen</string>
     <string name="bt_use_a_different_phone_number">Käytä toista puhelinnumeroa</string>
-    <string name="bt_sms_code_sent_to">Anna tekstiviestikoodi, joka on lähetetty numeroon %s</string>
+    <string name="bt_sms_code_sent_to">Anna tekstiviestikoodi, joka on lähetetty numeroon %1$s</string>
     <string name="bt_card_details">Kortin tiedot</string>
     <string name="bt_confirm_enrollment">Vahvista rekisteröityminen</string>
     <string name="bt_postal_code_invalid">Postinumero on virheellinen</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Tallennetut maksutavat</string>
     <string name="bt_supported_payments">Tuetut maksutavat</string>
     <string name="bt_edit_button_description">Muokkaa tallennettuja maksutapoja</string>
+    <string name="bt_card_already_exists">Tämä luottokortti on jo tallennettu maksutavaksi.</string>
 </resources>

--- a/Drop-In/src/main/res/values-fr-rCA/strings.xml
+++ b/Drop-In/src/main/res/values-fr-rCA/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Code par message texte</string>
     <string name="bt_sms_code_required">Le code envoyé par message texte est obligatoire.</string>
     <string name="bt_use_a_different_phone_number">Utiliser un autre numéro de téléphone</string>
-    <string name="bt_sms_code_sent_to">Saisir le code envoyé par message texte au %s</string>
+    <string name="bt_sms_code_sent_to">Saisir le code envoyé par message texte au %1$s</string>
     <string name="bt_card_details">Détails de la carte</string>
     <string name="bt_confirm_enrollment">Confirmer l\'inscription</string>
     <string name="bt_postal_code_invalid">Le code postal n\'est pas valide.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Modes de paiement enregistrés</string>
     <string name="bt_supported_payments">Modes de paiement pris en charge</string>
     <string name="bt_edit_button_description">Modifier les modes de paiement enregistrés</string>
+    <string name="bt_card_already_exists">Cette carte de crédit est déjà liée en tant que mode de paiement.</string>
 </resources>

--- a/Drop-In/src/main/res/values-fr-rXC/strings.xml
+++ b/Drop-In/src/main/res/values-fr-rXC/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Code envoyé par SMS</string>
     <string name="bt_sms_code_required">Le code envoyé par SMS est requis</string>
     <string name="bt_use_a_different_phone_number">Utilisez un autre numéro de téléphone</string>
-    <string name="bt_sms_code_sent_to">Saisissez le code envoyé par SMS au %s</string>
+    <string name="bt_sms_code_sent_to">Saisissez le code envoyé par SMS au %1$s</string>
     <string name="bt_card_details">Informations de carte</string>
     <string name="bt_confirm_enrollment">Confirmer l\'inscription</string>
     <string name="bt_postal_code_invalid">Le code postal est incorrect</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Modes de paiement enregistrés</string>
     <string name="bt_supported_payments">Modes de paiement pris en charge</string>
     <string name="bt_edit_button_description">Modifier les modes de paiement enregistrés</string>
+    <string name="bt_card_already_exists">Cette carte bancaire existe déjà en tant que mode de paiement enregistré.</string>
 </resources>

--- a/Drop-In/src/main/res/values-fr/strings.xml
+++ b/Drop-In/src/main/res/values-fr/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Code envoyé par SMS</string>
     <string name="bt_sms_code_required">Le code envoyé par SMS est requis.</string>
     <string name="bt_use_a_different_phone_number">Utiliser un autre numéro de téléphone</string>
-    <string name="bt_sms_code_sent_to">Saisissez le code envoyé par SMS au %s.</string>
+    <string name="bt_sms_code_sent_to">Saisissez le code envoyé par SMS au %1$s.</string>
     <string name="bt_card_details">Informations de carte</string>
     <string name="bt_confirm_enrollment">Confirmer l\'inscription</string>
     <string name="bt_postal_code_invalid">Le code postal est incorrect.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Modes de paiement enregistrés</string>
     <string name="bt_supported_payments">Modes de paiement pris en charge</string>
     <string name="bt_edit_button_description">Modifier les modes de paiement enregistrés</string>
+    <string name="bt_card_already_exists">Cette carte bancaire existe déjà en tant que mode de paiement enregistré.</string>
 </resources>

--- a/Drop-In/src/main/res/values-he/strings.xml
+++ b/Drop-In/src/main/res/values-he/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">קוד הודעת טקסט</string>
     <string name="bt_sms_code_required">נדרש קוד הודעת טקסט</string>
     <string name="bt_use_a_different_phone_number">השתמש במספר טלפון אחר</string>
-    <string name="bt_sms_code_sent_to">עליך להזין את קוד הודעת הטקסט שנשלח אל %s</string>
+    <string name="bt_sms_code_sent_to">עליך להזין את קוד הודעת הטקסט שנשלח אל %1$s</string>
     <string name="bt_card_details">פרטי הכרטיס</string>
     <string name="bt_confirm_enrollment">אישור ההרשמה</string>
     <string name="bt_postal_code_invalid">המיקוד אינו חוקי</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">שיטות תשלום שמורות</string>
     <string name="bt_supported_payments">שיטות תשלום נתמכות</string>
     <string name="bt_edit_button_description">עריכת שיטות תשלום שמורות</string>
+    <string name="bt_card_already_exists">כרטיס אשראי זה כבר שמור כשיטת תשלום.</string>
 </resources>

--- a/Drop-In/src/main/res/values-hu/strings.xml
+++ b/Drop-In/src/main/res/values-hu/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS-kód</string>
     <string name="bt_sms_code_required">Az SMS-kód megadása kötelező</string>
     <string name="bt_use_a_different_phone_number">Másik telefonszám használata</string>
-    <string name="bt_sms_code_sent_to">Adja meg a(z) %s számra küldött SMS-kódot</string>
+    <string name="bt_sms_code_sent_to">Adja meg a(z) %1$s számra küldött SMS-kódot</string>
     <string name="bt_card_details">Kártyaadatok</string>
     <string name="bt_confirm_enrollment">Jelentkezés megerősítése</string>
     <string name="bt_postal_code_invalid">Érvénytelen irányítószám</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Mentett fizetési módok</string>
     <string name="bt_supported_payments">Támogatott fizetési módok</string>
     <string name="bt_edit_button_description">Mentett fizetési módok szerkesztése</string>
+    <string name="bt_card_already_exists">Ez a hitelkártya már meg van adva mentett fizetési módként.</string>
 </resources>

--- a/Drop-In/src/main/res/values-id/strings.xml
+++ b/Drop-In/src/main/res/values-id/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Kode SMS</string>
     <string name="bt_sms_code_required">Kode SMS wajib diisi</string>
     <string name="bt_use_a_different_phone_number">Gunakan nomor telepon lain</string>
-    <string name="bt_sms_code_sent_to">Masukkan kode SMS yang dikirim ke %s</string>
+    <string name="bt_sms_code_sent_to">Masukkan kode SMS yang dikirim ke %1$s</string>
     <string name="bt_card_details">Perincian Kartu</string>
     <string name="bt_confirm_enrollment">Konfirmasikan Pendaftaran</string>
     <string name="bt_postal_code_invalid">Kode pos tidak valid</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Metode pembayaran tersimpan</string>
     <string name="bt_supported_payments">Metode pembayaran yang didukung</string>
     <string name="bt_edit_button_description">Edit metode pembayaran tersimpan</string>
+    <string name="bt_card_already_exists">Kartu kredit ini telah ada sebelumnya sebagai metode pembayaran tersimpan.</string>
 </resources>

--- a/Drop-In/src/main/res/values-it/strings.xml
+++ b/Drop-In/src/main/res/values-it/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Codice SMS</string>
     <string name="bt_sms_code_required">Il codice SMS è obbligatorio</string>
     <string name="bt_use_a_different_phone_number">Usa un altro numero di telefono</string>
-    <string name="bt_sms_code_sent_to">Immetti il codice SMS inviato a %s</string>
+    <string name="bt_sms_code_sent_to">Immetti il codice SMS inviato a %1$s</string>
     <string name="bt_card_details">Dati della carta</string>
     <string name="bt_confirm_enrollment">Conferma registrazione</string>
     <string name="bt_postal_code_invalid">Il CAP non è valido</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Metodi di pagamento salvati</string>
     <string name="bt_supported_payments">Metodi di pagamento supportati</string>
     <string name="bt_edit_button_description">Modifica metodi di pagamento salvati</string>
+    <string name="bt_card_already_exists">Questa carta di credito esiste già come metodo di pagamento salvato.</string>
 </resources>

--- a/Drop-In/src/main/res/values-iw/strings.xml
+++ b/Drop-In/src/main/res/values-iw/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">קוד הודעת טקסט</string>
     <string name="bt_sms_code_required">נדרש קוד הודעת טקסט</string>
     <string name="bt_use_a_different_phone_number">השתמש במספר טלפון אחר</string>
-    <string name="bt_sms_code_sent_to">עליך להזין את קוד הודעת הטקסט שנשלח אל %s</string>
+    <string name="bt_sms_code_sent_to">עליך להזין את קוד הודעת הטקסט שנשלח אל %1$s</string>
     <string name="bt_card_details">פרטי הכרטיס</string>
     <string name="bt_confirm_enrollment">אישור ההרשמה</string>
     <string name="bt_postal_code_invalid">המיקוד אינו חוקי</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">שיטות תשלום שמורות</string>
     <string name="bt_supported_payments">שיטות תשלום נתמכות</string>
     <string name="bt_edit_button_description">עריכת שיטות תשלום שמורות</string>
+    <string name="bt_card_already_exists">כרטיס אשראי זה כבר שמור כשיטת תשלום.</string>
 </resources>

--- a/Drop-In/src/main/res/values-ja/strings.xml
+++ b/Drop-In/src/main/res/values-ja/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMSコード</string>
     <string name="bt_sms_code_required">SMSコードが必要です</string>
     <string name="bt_use_a_different_phone_number">別の電話番号を使用する</string>
-    <string name="bt_sms_code_sent_to">%sに送信されたSMSコードを入力します</string>
+    <string name="bt_sms_code_sent_to">%1$sに送信されたSMSコードを入力します</string>
     <string name="bt_card_details">カードの詳細情報</string>
     <string name="bt_confirm_enrollment">登録の確認</string>
     <string name="bt_postal_code_invalid">郵便番号が正しくありません</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">保存済みの支払方法</string>
     <string name="bt_supported_payments">サポートされている支払方法</string>
     <string name="bt_edit_button_description">保存済みの支払方法を編集する</string>
+    <string name="bt_card_already_exists">このクレジットカードは、保存済みの支払方法としてすでに登録されています。</string>
 </resources>

--- a/Drop-In/src/main/res/values-ko/strings.xml
+++ b/Drop-In/src/main/res/values-ko/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS 코드</string>
     <string name="bt_sms_code_required">SMS 코드가 필요합니다.</string>
     <string name="bt_use_a_different_phone_number">다른 전화번호 사용하기</string>
-    <string name="bt_sms_code_sent_to">%s에 전송된 SMS 코드를 입력하세요.</string>
+    <string name="bt_sms_code_sent_to">%1$s에 전송된 SMS 코드를 입력하세요.</string>
     <string name="bt_card_details">카드 세부정보</string>
     <string name="bt_confirm_enrollment">등록 확인</string>
     <string name="bt_postal_code_invalid">우편번호가 올바르지 않습니다.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">저장된 결제수단</string>
     <string name="bt_supported_payments">지원되는 결제수단</string>
     <string name="bt_edit_button_description">저장된 결제수단 편집</string>
+    <string name="bt_card_already_exists">이 신용카드는 이미 저장된 결제수단으로 설정되어 있습니다.</string>
 </resources>

--- a/Drop-In/src/main/res/values-nb/strings.xml
+++ b/Drop-In/src/main/res/values-nb/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS-kode</string>
     <string name="bt_sms_code_required">SMS-kode er obligatorisk</string>
     <string name="bt_use_a_different_phone_number">Bruk et annet telefonnummer</string>
-    <string name="bt_sms_code_sent_to">Skriv inn SMS-koden som er sendt til %s</string>
+    <string name="bt_sms_code_sent_to">Skriv inn SMS-koden som er sendt til %1$s</string>
     <string name="bt_card_details">Kortdetaljer</string>
     <string name="bt_confirm_enrollment">Bekreft registrering</string>
     <string name="bt_postal_code_invalid">Postnummeret er ugyldig</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Lagret betalingsmetode</string>
     <string name="bt_supported_payments">Støttede betalingsmetoder</string>
     <string name="bt_edit_button_description">Rediger lagrede betalingsmetoder</string>
+    <string name="bt_card_already_exists">Dette betalingskortet finnes allerede som en lagret betalingsmetode.</string>
 </resources>

--- a/Drop-In/src/main/res/values-nl/strings.xml
+++ b/Drop-In/src/main/res/values-nl/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Sms-code</string>
     <string name="bt_sms_code_required">Sms-code is vereist</string>
     <string name="bt_use_a_different_phone_number">Een ander telefoonnummer gebruiken</string>
-    <string name="bt_sms_code_sent_to">Voer de sms-code in die naar %s is gestuurd</string>
+    <string name="bt_sms_code_sent_to">Voer de sms-code in die naar %1$s is gestuurd</string>
     <string name="bt_card_details">Kaartgegevens</string>
     <string name="bt_confirm_enrollment">Inschrijving bevestigen</string>
     <string name="bt_postal_code_invalid">Postcode is ongeldig</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Opgeslagen betaalmethoden</string>
     <string name="bt_supported_payments">Ondersteunde betaalmethoden</string>
     <string name="bt_edit_button_description">Opgeslagen betaalmethoden bewerken</string>
+    <string name="bt_card_already_exists">Deze creditcard bestaat al als opgeslagen betaalmethode.</string>
 </resources>

--- a/Drop-In/src/main/res/values-pl/strings.xml
+++ b/Drop-In/src/main/res/values-pl/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Kod SMS</string>
     <string name="bt_sms_code_required">Kod SMS jest wymagany.</string>
     <string name="bt_use_a_different_phone_number">Podaj inny numer telefonu</string>
-    <string name="bt_sms_code_sent_to">Wprowadź kod SMS wysłany na numer %s.</string>
+    <string name="bt_sms_code_sent_to">Wprowadź kod SMS wysłany na numer %1$s.</string>
     <string name="bt_card_details">Dane karty</string>
     <string name="bt_confirm_enrollment">Potwierdź rejestrację</string>
     <string name="bt_postal_code_invalid">Kod pocztowy jest nieprawidłowy.</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Zapisane źródła finansowania płatności</string>
     <string name="bt_supported_payments">Obsługiwane źródła finansowania płatności</string>
     <string name="bt_edit_button_description">Edytuj zapisane źródła finansowania płatności</string>
+    <string name="bt_card_already_exists">Ta karta kredytowa istnieje jako zapisana forma płatności.</string>
 </resources>

--- a/Drop-In/src/main/res/values-pt/strings.xml
+++ b/Drop-In/src/main/res/values-pt/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Código SMS</string>
     <string name="bt_sms_code_required">O Código SMS é obrigatório</string>
     <string name="bt_use_a_different_phone_number">Usar outro número de telefone</string>
-    <string name="bt_sms_code_sent_to">Introduzir código SMS enviado para %s</string>
+    <string name="bt_sms_code_sent_to">Introduzir código SMS enviado para %1$s</string>
     <string name="bt_card_details">Detalhes do cartão</string>
     <string name="bt_confirm_enrollment">Confirmar inscrição</string>
     <string name="bt_postal_code_invalid">O Código postal é inválido</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Meios de pagamento guardados</string>
     <string name="bt_supported_payments">Meios de pagamento suportados</string>
     <string name="bt_edit_button_description">Editar meios de pagamento guardados</string>
+    <string name="bt_card_already_exists">Este cartão de crédito já existe como meio de pagamento guardado.</string>
 </resources>

--- a/Drop-In/src/main/res/values-ru/strings.xml
+++ b/Drop-In/src/main/res/values-ru/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Код, указанный в SMS-сообщении</string>
     <string name="bt_sms_code_required">Необходимо ввести код подтверждения, указанный в SMS-сообщении</string>
     <string name="bt_use_a_different_phone_number">Использовать другой номер телефона</string>
-    <string name="bt_sms_code_sent_to">Введите код, указанный в SMS-сообщении, отправленном на %s</string>
+    <string name="bt_sms_code_sent_to">Введите код, указанный в SMS-сообщении, отправленном на %1$s</string>
     <string name="bt_card_details">Данные карты</string>
     <string name="bt_confirm_enrollment">Подтвердить регистрацию</string>
     <string name="bt_postal_code_invalid">Почтовый индекс недействительный</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Сохраненные способы оплаты</string>
     <string name="bt_supported_payments">Поддерживаемые способы оплаты</string>
     <string name="bt_edit_button_description">Изменить сохраненные способы оплаты</string>
+    <string name="bt_card_already_exists">Данная кредитная карта уже существует как сохраненный способ оплаты.</string>
 </resources>

--- a/Drop-In/src/main/res/values-sk/strings.xml
+++ b/Drop-In/src/main/res/values-sk/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">Kód SMS</string>
     <string name="bt_sms_code_required">Vyžaduje sa kód SMS</string>
     <string name="bt_use_a_different_phone_number">Použiť iné telefónne číslo</string>
-    <string name="bt_sms_code_sent_to">Zadajte kód SMS zaslaný na číslo %s</string>
+    <string name="bt_sms_code_sent_to">Zadajte kód SMS zaslaný na číslo %1$s</string>
     <string name="bt_card_details">Údaje o karte</string>
     <string name="bt_confirm_enrollment">Potvrdiť registráciu</string>
     <string name="bt_postal_code_invalid">PSČ je neplatné</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Uložené spôsoby platby</string>
     <string name="bt_supported_payments">Podporované spôsoby platby</string>
     <string name="bt_edit_button_description">Upraviť uložené spôsoby platby</string>
+    <string name="bt_card_already_exists">Táto kreditná karta už existuje ako uložený spôsob platby.</string>
 </resources>

--- a/Drop-In/src/main/res/values-sv/strings.xml
+++ b/Drop-In/src/main/res/values-sv/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS-kod</string>
     <string name="bt_sms_code_required">Du måste ange en SMS-kod</string>
     <string name="bt_use_a_different_phone_number">Använd ett annat telefonnummer</string>
-    <string name="bt_sms_code_sent_to">Ange SMS-koden som skickats till %s</string>
+    <string name="bt_sms_code_sent_to">Ange SMS-koden som skickats till %1$s</string>
     <string name="bt_card_details">Kortuppgifter</string>
     <string name="bt_confirm_enrollment">Bekräfta registrering</string>
     <string name="bt_postal_code_invalid">Postnumret är ogiltigt</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Sparade betalningsmetoder</string>
     <string name="bt_supported_payments">Betalningsmetoder som stöds</string>
     <string name="bt_edit_button_description">Ändra sparade betalningsmetoder</string>
+    <string name="bt_card_already_exists">Det här kreditkortet finns redan som en sparad betalningsmetod.</string>
 </resources>

--- a/Drop-In/src/main/res/values-th/strings.xml
+++ b/Drop-In/src/main/res/values-th/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">รหัส SMS</string>
     <string name="bt_sms_code_required">ต้องระบุรหัส SMS</string>
     <string name="bt_use_a_different_phone_number">โปรดใช้หมายเลขโทรศัพท์อื่น</string>
-    <string name="bt_sms_code_sent_to">ป้อนรหัส SMS ที่ส่งไปยัง %s</string>
+    <string name="bt_sms_code_sent_to">ป้อนรหัส SMS ที่ส่งไปยัง %1$s</string>
     <string name="bt_card_details">รายละเอียดบัตร</string>
     <string name="bt_confirm_enrollment">ยืนยันการลงทะเบียน</string>
     <string name="bt_postal_code_invalid">รหัสไปรษณีย์ไม่ถูกต้อง</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">วิธีการชำระเงินที่บันทึกไว้</string>
     <string name="bt_supported_payments">วิธีการชําระเงินที่รองรับ</string>
     <string name="bt_edit_button_description">แก้ไขวิธีการชําระเงินที่บันทึกไว้</string>
+    <string name="bt_card_already_exists">บัตรเครดิตนี้เป็นวิธีการชำระเงินที่บันทึกไว้แล้ว</string>
 </resources>

--- a/Drop-In/src/main/res/values-zh-rCN/strings.xml
+++ b/Drop-In/src/main/res/values-zh-rCN/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">短信验证码</string>
     <string name="bt_sms_code_required">短信验证码为必填项</string>
     <string name="bt_use_a_different_phone_number">使用其它电话号码</string>
-    <string name="bt_sms_code_sent_to">请输入发送到%s的短信验证码</string>
+    <string name="bt_sms_code_sent_to">请输入发送到%1$s的短信验证码</string>
     <string name="bt_card_details">卡详细信息</string>
     <string name="bt_confirm_enrollment">确认注册</string>
     <string name="bt_postal_code_invalid">邮政编码无效</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">已保存的付款方式</string>
     <string name="bt_supported_payments">受支持的付款方式</string>
     <string name="bt_edit_button_description">编辑已保存的付款方式</string>
+    <string name="bt_card_already_exists">此信用卡已存在于已保存的付款方式。</string>
 </resources>

--- a/Drop-In/src/main/res/values-zh-rHK/strings.xml
+++ b/Drop-In/src/main/res/values-zh-rHK/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">SMS 代碼</string>
     <string name="bt_sms_code_required">必須填寫 SMS 代碼</string>
     <string name="bt_use_a_different_phone_number">使用其他電話號碼</string>
-    <string name="bt_sms_code_sent_to">請輸入發送到 %s 的代碼</string>
+    <string name="bt_sms_code_sent_to">請輸入發送到 %1$s 的代碼</string>
     <string name="bt_card_details">信用卡詳細資料</string>
     <string name="bt_confirm_enrollment">確認登記</string>
     <string name="bt_postal_code_invalid">郵遞區號無效</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">已儲存的付款方式</string>
     <string name="bt_supported_payments">支援的付款方式</string>
     <string name="bt_edit_button_description">編輯已儲存的付款方式</string>
+    <string name="bt_card_already_exists">此信用卡為已儲存的付款方式。</string>
 </resources>

--- a/Drop-In/src/main/res/values-zh-rTW/strings.xml
+++ b/Drop-In/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">簡訊代碼</string>
     <string name="bt_sms_code_required">簡訊代碼為必填</string>
     <string name="bt_use_a_different_phone_number">請使用其他電話號碼</string>
-    <string name="bt_sms_code_sent_to">請輸入發送至 %s 的簡訊代碼</string>
+    <string name="bt_sms_code_sent_to">請輸入發送至 %1$s 的簡訊代碼</string>
     <string name="bt_card_details">信用卡詳細資料</string>
     <string name="bt_confirm_enrollment">確認登記</string>
     <string name="bt_postal_code_invalid">郵遞區號無效</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">儲存的付款方式</string>
     <string name="bt_supported_payments">支援的付款方式</string>
     <string name="bt_edit_button_description">編輯儲存的付款方式</string>
+    <string name="bt_card_already_exists">此信用卡已經是儲存的付款方式。</string>
 </resources>

--- a/Drop-In/src/main/res/values-zh-rXC/strings.xml
+++ b/Drop-In/src/main/res/values-zh-rXC/strings.xml
@@ -25,7 +25,7 @@
     <string name="bt_sms_code">短信验证码</string>
     <string name="bt_sms_code_required">短信验证码为必填项</string>
     <string name="bt_use_a_different_phone_number">使用其它电话号码</string>
-    <string name="bt_sms_code_sent_to">请输入发送到%s的短信验证码</string>
+    <string name="bt_sms_code_sent_to">请输入发送到%1$s的短信验证码</string>
     <string name="bt_card_details">卡详细信息</string>
     <string name="bt_confirm_enrollment">确认注册</string>
     <string name="bt_postal_code_invalid">邮政编码无效</string>
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">已保存的付款方式</string>
     <string name="bt_supported_payments">受支持的付款方式</string>
     <string name="bt_edit_button_description">编辑已保存的付款方式</string>
+    <string name="bt_card_already_exists">此信用卡已存在于已保存的付款方式中。</string>
 </resources>

--- a/Drop-In/src/main/res/values/strings.xml
+++ b/Drop-In/src/main/res/values/strings.xml
@@ -46,4 +46,5 @@
     <string name="bt_saved_payments">Saved payment methods</string>
     <string name="bt_supported_payments">Supported payment methods</string>
     <string name="bt_edit_button_description">Edit saved payment methods</string>
+    <string name="bt_card_already_exists">This credit card already exists as a saved payment method.</string>
 </resources>

--- a/Drop-In/src/sharedTest/java/com/braintreepayments/api/Fixtures.kt
+++ b/Drop-In/src/sharedTest/java/com/braintreepayments/api/Fixtures.kt
@@ -325,42 +325,6 @@ object Fixtures {
     """
 
     // language=JSON
-    const val CREDIT_CARD_NON_NUMBER_ERROR_RESPONSE = """
-        {
-          "error": {
-            "message": "Credit card is invalid"
-          },
-          "fieldErrors": [
-            {
-              "field": "creditCard",
-              "fieldErrors": [
-                {
-                  "field": "billingAddress",
-                  "message": "Postal code is invalid"
-                },
-                {
-                  "field": "cvv",
-                  "message": "CVV is invalid"
-                },
-                {
-                  "field": "expirationMonth",
-                  "message": "Expiration month is invalid"
-                },
-                {
-                  "field": "expirationYear",
-                  "message": "Expiration year is invalid"
-                },
-                {
-                  "field": "base",
-                  "message": "Credit card must include number, payment_method_nonce, or venmo_sdk_payment_method_code"
-                }
-              ]
-            }
-          ]
-        }
-    """
-
-    // language=JSON
     const val GET_PAYMENT_METHODS_EMPTY_RESPONSE = """
         {
           "paymentMethods": []
@@ -741,20 +705,4 @@ object Fixtures {
         }
     """
 
-    // language=JSON
-    const val PAYMENT_METHODS_VENMO_ACCOUNT_RESPONSE = """
-        {
-          "venmoAccounts": [{
-            "type": "VenmoAccount",
-            "nonce": "fake-venmo-nonce",
-            "description": "VenmoAccount",
-            "consumed": false,
-            "default": true,
-            "details": {
-              "cardType": "Discover",
-              "username": "venmojoe"
-            }
-          }]
-        }
-    """
 }


### PR DESCRIPTION
### Summary of changes

 - Bump braintree_android module dependency versions to `4.15.0`
 - Parse duplicate payment method error internally
 - Notify merchant via error message the payment method is duplicated (fixes #357)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
