### PR TITLE
Prevent Add Card Button Double Tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Fix issue that caused Add Card button to attempt tokenization multiple times when double tapped.
+
 ## 6.5.0
 
 * Add `DropInClient#invalidateClientToken()` method (fixes #367)

--- a/Drop-In/src/main/java/com/braintreepayments/api/AnimatedButtonView.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AnimatedButtonView.java
@@ -49,10 +49,16 @@ class AnimatedButtonView extends RelativeLayout implements OnClickListener {
 
     @Override
     public void onClick(View view) {
-        showLoading();
-        if (onClickListener != null) {
-            onClickListener.onClick(this);
+        if (!isLoading()) {
+            showLoading();
+            if (onClickListener != null) {
+                onClickListener.onClick(this);
+            }
         }
+    }
+
+    private boolean isLoading() {
+        return (viewAnimator.getDisplayedChild() == 1);
     }
 
     public void showButton() {

--- a/Drop-In/src/test/java/com/braintreepayments/api/AnimatedButtonViewUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/AnimatedButtonViewUnitTest.java
@@ -66,7 +66,7 @@ public class AnimatedButtonViewUnitTest {
     }
 
     @Test
-    public void onClick_whenLoaderIsVisible_doesNotCallClickListener() {
+    public void onClick_whenLoaderIsVisible_doesNotCallOnClickListener() {
         view.showLoading();
 
         OnClickListener listener = mock(OnClickListener.class);

--- a/Drop-In/src/test/java/com/braintreepayments/api/AnimatedButtonViewUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/AnimatedButtonViewUnitTest.java
@@ -2,6 +2,7 @@ package com.braintreepayments.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import android.util.AttributeSet;
@@ -55,13 +56,24 @@ public class AnimatedButtonViewUnitTest {
     }
 
     @Test
-    public void onClick_callsOnClickListener() {
+    public void onClick_whenLoaderIsHidden_callsOnClickListener() {
         OnClickListener listener = mock(OnClickListener.class);
         view.setClickListener(listener);
 
         view.onClick(null);
 
         verify(listener).onClick(view);
+    }
+
+    @Test
+    public void onClick_whenLoaderIsVisible_doesNotCallClickListener() {
+        view.showLoading();
+
+        OnClickListener listener = mock(OnClickListener.class);
+        view.setClickListener(listener);
+        view.onClick(null);
+
+        verify(listener, never()).onClick(view);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Fix issue that caused Add Card button to attempt tokenization multiple times when double tapped.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
