### PR TITLE
Bump `braintree_android` Dependency Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android module dependency versions to `4.21.1`
+
 ## 6.5.1
 
 * Fix issue that caused Add Card button to attempt tokenization multiple times when double tapped.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.20.0"
+    ext.brainTreeVersion = "4.21.1"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION

### Summary of changes

 - Bump braintree_android module dependency versions to `4.21.1`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 