### PR TITLE
Update Braintree Core SDK to 4.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android module dependency versions to `4.23.1`
+
 ## 6.6.0
 
 * Bump braintree_android module dependency versions to `4.23.0`

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.23.0"
+    ext.brainTreeVersion = "4.23.1"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Bump `braintree_android` module dependency versions to `4.23.1`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire