### PR TITLE
Fix Duplicate Payment Method Bottom Sheet Loader Stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Fix issue that causes the DropIn UI to hang when a duplicate payment method is entered and user returns to Bottom Sheet view (fixes #370)
+
 ## 6.7.0
 
 * Bump braintree_android module dependency versions to `4.23.1`

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -438,9 +438,11 @@ public class DropInActivity extends AppCompatActivity {
 
     private void startAddCardFlow(@Nullable String cardNumber) {
         // clear card tokenization error to prevent Error UI from a previous duplicate card submission
-        // TODO: migrate card tokenization error state from activity view model into fragments own
-        // view model to prevent UI bugs with previous submissions
         dropInViewModel.setCardTokenizationError(null);
+        // TODO: 👆 isolate transactional state within the calling fragment to prevent stale data
+        // in the activity view model from causes UI bugs; in this case, we should migrate the card
+        // tokenization error out of the activity view model's scope and contain the state within
+        // the scope of the CardDetailsFragment that's making the request
 
         if (shouldAddFragment(ADD_CARD_TAG)) {
             AddCardFragment addCardFragment = AddCardFragment.from(dropInRequest, cardNumber);

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -440,9 +440,9 @@ public class DropInActivity extends AppCompatActivity {
         // clear card tokenization error to prevent Error UI from a previous duplicate card submission
         dropInViewModel.setCardTokenizationError(null);
         // TODO: 👆 isolate transactional state within the calling fragment to prevent stale data
-        // in the activity view model from causes UI bugs; in this case, we should migrate the card
-        // tokenization error out of the activity view model's scope and contain the state within
-        // the scope of the CardDetailsFragment that's making the request
+        // in the activity view model from causing UI bugs; in this case, we should migrate the card
+        // tokenization error out of the activity view model's scope and contain the error state
+        // within the scope of the CardDetailsFragment that's making the request
 
         if (shouldAddFragment(ADD_CARD_TAG)) {
             AddCardFragment addCardFragment = AddCardFragment.from(dropInRequest, cardNumber);

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -502,6 +502,7 @@ public class DropInActivity extends AppCompatActivity {
             if (error != null) {
                 if (error instanceof ErrorWithResponse) {
                     dropInViewModel.setCardTokenizationError(error);
+                    dropInViewModel.setDropInState(DropInState.IDLE);
                 } else {
                     onError(error);
                 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -437,6 +437,11 @@ public class DropInActivity extends AppCompatActivity {
     }
 
     private void startAddCardFlow(@Nullable String cardNumber) {
+        // clear card tokenization error to prevent Error UI from a previous duplicate card submission
+        // TODO: migrate card tokenization error state from activity view model into fragments own
+        // view model to prevent UI bugs with previous submissions
+        dropInViewModel.setCardTokenizationError(null);
+
         if (shouldAddFragment(ADD_CARD_TAG)) {
             AddCardFragment addCardFragment = AddCardFragment.from(dropInRequest, cardNumber);
             replaceExistingFragment(addCardFragment, ADD_CARD_TAG);

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
@@ -688,13 +688,14 @@ class DropInActivityUnitTest {
     }
 
     @Test
-    fun onSupportedPaymentMethodSelectedEvent_withTypeUnknown_showsAddCardFragment() {
+    fun onSupportedPaymentMethodSelectedEvent_withTypeUnknown_showsAddCardFragmentAndClearsCardTokenizationError() {
         val dropInClient = MockDropInInternalClientBuilder()
             .authorizationSuccess(authorization)
             .getConfigurationSuccess(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY_AND_CARD_AND_PAYPAL))
             .getSupportedPaymentMethodsSuccess(ArrayList())
             .build()
         setupDropInActivity(dropInClient, dropInRequest)
+        activity.dropInViewModel.setCardTokenizationError(Exception("card tokenization error"))
 
         val event =
             DropInEvent.createSupportedPaymentMethodSelectedEvent(DropInPaymentMethod.UNKNOWN)
@@ -702,6 +703,7 @@ class DropInActivityUnitTest {
         activity.supportFragmentManager.executePendingTransactions()
 
         assertNotNull(activity.supportFragmentManager.findFragmentByTag("ADD_CARD"))
+        assertNull(activity.dropInViewModel.cardTokenizationError.value)
     }
 
     @Test
@@ -767,7 +769,7 @@ class DropInActivityUnitTest {
     // region Add Card Submit Event
 
     @Test
-    fun onAddCardSubmitEvent_showsCardDetailsFragment() {
+    fun onAddCardSubmitEvent_showsCardDetailsFragmentAndClearsCardTokenizationError() {
         val dropInClient = MockDropInInternalClientBuilder()
             .authorizationSuccess(authorization)
             .getConfigurationSuccess(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY_AND_CARD_AND_PAYPAL))

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
@@ -890,6 +890,7 @@ class DropInActivityUnitTest {
         activity.supportFragmentManager.setFragmentResult(DropInEvent.REQUEST_KEY, event.toBundle())
 
         assertEquals(error, activity.dropInViewModel.cardTokenizationError.value)
+        assertEquals(DropInState.IDLE, activity.dropInViewModel.dropInState.value)
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - This PR contains a fix for #370
 - The Bottom Sheet loader is stuck when a duplicate payment method is entered

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
- @jaxdesmarais (help with testing)