### PR TITLE
Add Browser Switch Note in Migration Guide

### DIFF
--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -14,6 +14,7 @@ v6 of the Drop-In SDK requires v4 of the [Braintree Android SDK](https://github.
 1. [Launch Drop-In](#launch-drop-in)
 1. [Handle Drop-In Result](#handle-drop-in-result)
 1. [Fetch Last Used Payment Method](#fetch-last-used-payment-method)
+1. [Browser Switch](#browser-switch)
 
 ## Gradle
 
@@ -244,3 +245,8 @@ Kotlin:
         // handle result
     }
 ```
+
+## Browser Switch
+
+DropIn handles browser switching internally. Any payment method that requires a browser switch will work automatically.
+


### PR DESCRIPTION
### Summary of changes

 - Add note in Migration Guide that Browser Switch is configured automatically in DropIn
 - Fix for [braintree/braintree_android #692](https://github.com/braintree/braintree_android/issues/692)

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors

- @sshropshire
