### PR TITLE
Fix Bug where Payment Methods can be Selected Multiple Times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Dismiss keyboard and submit form on Card Details when form is complete and `Enter` is pressed
+* Fix bug where payment methods can be selected multiple times
 
 ## 6.8.0
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/SupportedPaymentMethodsFragment.java
@@ -182,14 +182,16 @@ public class SupportedPaymentMethodsFragment extends DropInFragment implements S
 
     @Override
     public void onPaymentMethodSelected(DropInPaymentMethod type) {
-        boolean paymentTypeWillInitiateAsyncRequest = (type == DropInPaymentMethod.PAYPAL)
-                || (type == DropInPaymentMethod.VENMO);
+        if (viewState == ViewState.SHOW_PAYMENT_METHODS) {
+            boolean paymentTypeWillInitiateAsyncRequest = (type == DropInPaymentMethod.PAYPAL)
+                    || (type == DropInPaymentMethod.VENMO);
 
-        if (paymentTypeWillInitiateAsyncRequest) {
-            setViewState(ViewState.LOADING);
+            if (paymentTypeWillInitiateAsyncRequest) {
+                setViewState(ViewState.LOADING);
+            }
+            sendDropInEvent(
+                    DropInEvent.createSupportedPaymentMethodSelectedEvent(type));
         }
-        sendDropInEvent(
-                DropInEvent.createSupportedPaymentMethodSelectedEvent(type));
     }
 
     @Override


### PR DESCRIPTION
### Summary of changes

 - Fix bug where payment methods can be selected multiple times
     - As an example, clicking on PayPal in quick succession will open the PayPal window however many times you clicked the button
     - We can defensively check the state to disallow this
     - We attempted to write a UI Test for this but Android's Espresso used for our click events waits 2 seconds between clicks for the `doubleClick` event ([stackoverflow here](https://stackoverflow.com/questions/64482749/circularprogresslayout-not-double-clicking-in-espresso))

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire @jaxdesmarais 
