### PR TITLE
Only Allow Google Pay Launch When an Activity is in the Foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Prevent Google Pay from launching twice when double tapped
+
 ## 6.8.1
 
 * Dismiss keyboard and submit form on Card Details when form is complete and `Enter` is pressed

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.braintreepayments.api.dropin.R;
@@ -155,9 +156,11 @@ public class DropInActivity extends AppCompatActivity {
     }
 
     private void onSupportedPaymentMethodSelected(DropInEvent event) {
-        DropInPaymentMethod paymentMethodType =
-                event.getDropInPaymentMethodType(DropInEventProperty.SUPPORTED_PAYMENT_METHOD);
-        startPaymentFlow(paymentMethodType);
+        if (getLifecycle().getCurrentState() == Lifecycle.State.RESUMED) {
+            DropInPaymentMethod paymentMethodType =
+                    event.getDropInPaymentMethodType(DropInEventProperty.SUPPORTED_PAYMENT_METHOD);
+            startPaymentFlow(paymentMethodType);
+        }
     }
 
     private void startPaymentFlow(DropInPaymentMethod paymentMethodType) {

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
@@ -667,6 +667,26 @@ class DropInActivityUnitTest {
     }
 
     @Test
+    fun onSupportedPaymentMethodSelectedEvent_withTypeGooglePay_doesNothingWhenActivityIsPaused() {
+        val dropInClient = MockDropInInternalClientBuilder()
+            .authorizationSuccess(authorization)
+            .getConfigurationSuccess(Configuration.fromJson(Fixtures.CONFIGURATION_WITH_GOOGLE_PAY_AND_CARD_AND_PAYPAL))
+            .getSupportedPaymentMethodsSuccess(ArrayList())
+            .build()
+        setupDropInActivity(dropInClient, dropInRequest)
+        activityController.pause()
+
+        val event =
+            DropInEvent.createSupportedPaymentMethodSelectedEvent(DropInPaymentMethod.GOOGLE_PAY)
+        activity.supportFragmentManager.setFragmentResult(DropInEvent.REQUEST_KEY, event.toBundle())
+
+        verify(dropInClient, never()).requestGooglePayPayment(
+            same(activity),
+            any(GooglePayRequestPaymentCallback::class.java)
+        )
+    }
+
+    @Test
     fun onSupportedPaymentMethodSelectedEvent_withTypeGooglePay_onGooglePayError_finishesWithError() {
         val error = Exception("error")
         val dropInClient = MockDropInInternalClientBuilder()


### PR DESCRIPTION
### Summary of changes

 - To prevent a double tap from launching Google Pay twice, make sure the Activity is in the foreground before presenting the Google Pay flow

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
