### PR TITLE
Bump Braintree Dependency to 4.27.0

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -13,7 +13,6 @@ The Braintree SDK uses code from the following libraries:
  * [leakcanary](https://github.com/square/leakcanary), Apache License Version 2.0
  * [mailable-log](https://github.com/lkorth/mailable-log), MIT License
  * [Mockito](https://github.com/mockito/mockito), MIT License
- * [PowerMock](https://github.com/jayway/powermock), Apache License Version 2.0
  * [Retrofit](https://github.com/square/retrofit), Apache License Version 2.0
  * [Robolectric](https://github.com/robolectric/robolectric), MIT License
  * [SDK Manager Plugin](https://github.com/JakeWharton/sdk-manager-plugin), Apache License Version 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Prevent Google Pay from launching twice when double tapped
+* Bump braintree_android module dependency versions to `4.27.0`
 
 ## 6.8.1
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -90,29 +90,26 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation 'androidx.test:rules:1.4.0'
+    testImplementation 'androidx.test:runner:1.4.0'
+    testImplementation 'androidx.test:core:1.4.0'
+
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.robolectric:robolectric:4.7.3'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
 
-    testImplementation "androidx.core:core-ktx:1.6.0"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10"
-    testImplementation "androidx.test:core:1.4.0"
+    testImplementation 'androidx.core:core-ktx:1.6.0'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.work:work-testing:2.5.0'
     testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'org.mockito:mockito-core:3.6.0'
 
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.fragment:fragment-testing:1.3.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-
-    androidTestCompileOnly 'org.powermock:powermock-module-junit4:1.6.6'
-    androidTestCompileOnly 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    androidTestCompileOnly 'org.powermock:powermock-api-mockito:1.6.6'
-    androidTestCompileOnly 'org.powermock:powermock-classloading-xstream:1.6.6'
 }
 
 // region signing and publishing

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
@@ -9,13 +9,15 @@ import android.os.Bundle
 import androidx.test.platform.app.InstrumentationRegistry
 import com.braintreepayments.api.DropInClient.EXTRA_CHECKOUT_REQUEST
 import com.braintreepayments.cardform.utils.CardType
-import junit.framework.TestCase.*
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.same
 import org.mockito.Mockito.*
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -24,30 +24,20 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 
 import java.util.ArrayList;
-import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class DropInClientUnitTest {
-
-    @Captor
-    ArgumentCaptor<List<DropInPaymentMethod>> paymentMethodTypesCaptor;
-
-    @Captor
-    ArgumentCaptor<List<PaymentMethodNonce>> paymentMethodNoncesCaptor;
 
     private FragmentActivity activity;
     private DropInSharedPreferences dropInSharedPreferences;
 
     @Before
     public void beforeEach() {
-        MockitoAnnotations.initMocks(this);
 
         dropInSharedPreferences = mock(DropInSharedPreferences.class);
         ActivityController<FragmentActivity> activityController =

--- a/Drop-In/src/test/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/Drop-In/src/test/java/org/mockito/configuration/MockitoConfiguration.java
@@ -1,9 +1,0 @@
-package org.mockito.configuration;
-
-public class MockitoConfiguration extends DefaultMockitoConfiguration {
-
-    @Override
-    public boolean enableClassCache() {
-        return false;
-    }
-}

--- a/Drop-In/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/Drop-In/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.26.0"
+    ext.brainTreeVersion = "4.27.0"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Update Braintree Core SDK dependency version to `4.27.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @KunJeongPark 
