### PR TITLE
[5.x] Use Braintree SDK Version 3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android version to 3.21.0
+
 ## 5.4.1
 
 * Bump braintree_android version to 3.20.1

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,9 +58,9 @@ android {
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.20.1'
+    api 'com.braintreepayments.api:braintree:3.21.0'
     api 'com.braintreepayments:card-form:5.1.1'
-    api 'com.braintreepayments.api:three-d-secure:3.20.1'
+    api 'com.braintreepayments.api:three-d-secure:3.21.0'
 
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'


### PR DESCRIPTION
### Summary of changes

 - Bump braintree_android version to 3.21.0

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
