### PR TITLE
Property to Hide Card Logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Add California Privacy Laws notice of collection to credit card form
+* Add `DropInRequest.setCardLogosDisabled()` to hide card logos on the credit card form if desired
 
 ## 6.10.0
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -1,5 +1,7 @@
 package com.braintreepayments.api
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso.onView
@@ -187,5 +189,24 @@ class AddCardFragmentUITest {
         }
 
         onView(withId(R.id.bt_button)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun whenStateIsRESUMED_andCardholderNameDisabled_expirationDateFieldIsFocused() {
+        val dropInRequest = DropInRequest()
+        dropInRequest.setCardLogosDisabled(true);
+
+        val args = Bundle()
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
+        args.putString("EXTRA_CARD_NUMBER", VISA)
+
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onView(isRoot()).perform(waitFor(500))
+
+        scenario.onFragment { fragment ->
+            assertEquals(View.GONE, fragment.supportedCardTypesView.visibility);
+        }
     }
 }

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -192,7 +192,7 @@ class AddCardFragmentUITest {
     }
 
     @Test
-    fun whenStateIsRESUMED_andCardholderNameDisabled_expirationDateFieldIsFocused() {
+    fun whenStateIsRESUMED_andCardLogosDisabled_supportedCardTypesViewisGONE() {
         val dropInRequest = DropInRequest()
         dropInRequest.setCardLogosDisabled(true);
 

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -192,7 +192,7 @@ class AddCardFragmentUITest {
     }
 
     @Test
-    fun whenStateIsRESUMED_andCardLogosDisabled_supportedCardTypesViewisGONE() {
+    fun whenStateIsRESUMED_andCardLogosDisabled_supportedCardTypesViewIsGONE() {
         val dropInRequest = DropInRequest()
         dropInRequest.setCardLogosDisabled(true);
 
@@ -207,6 +207,24 @@ class AddCardFragmentUITest {
 
         scenario.onFragment { fragment ->
             assertEquals(View.GONE, fragment.supportedCardTypesView.visibility);
+        }
+    }
+
+    @Test
+    fun whenStateIsRESUMED_andCardLogosEnabled_supportedCardTypesViewIsVISIBLE() {
+        val dropInRequest = DropInRequest()
+
+        val args = Bundle()
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
+        args.putString("EXTRA_CARD_NUMBER", VISA)
+
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onView(isRoot()).perform(waitFor(500))
+
+        scenario.onFragment { fragment ->
+            assertEquals(View.VISIBLE, fragment.supportedCardTypesView.visibility);
         }
     }
 }

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -29,6 +29,8 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     private AccessibleSupportedCardTypesView supportedCardTypesView;
     private AnimatedButtonView animatedButtonView;
 
+    private static Boolean cardLogosDisabled;
+
     @VisibleForTesting
     DropInViewModel dropInViewModel;
 
@@ -41,6 +43,8 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
             args.putString("EXTRA_CARD_NUMBER", cardNumber);
         }
 
+        cardLogosDisabled = dropInRequest.areCardLogosDisabled();
+
         AddCardFragment instance = new AddCardFragment();
         instance.setArguments(args);
         return instance;
@@ -52,6 +56,11 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
 
         cardForm = view.findViewById(R.id.bt_card_form);
         supportedCardTypesView = view.findViewById(R.id.bt_supported_card_types);
+
+        if (cardLogosDisabled) {
+            supportedCardTypesView.setVisibility(View.GONE);
+        }
+
         animatedButtonView = view.findViewById(R.id.bt_animated_button_view);
 
         TextView textView = view.findViewById(R.id.bt_privacy_policy);

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -29,8 +29,6 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     private AccessibleSupportedCardTypesView supportedCardTypesView;
     private AnimatedButtonView animatedButtonView;
 
-    private static Boolean cardLogosDisabled;
-
     @VisibleForTesting
     DropInViewModel dropInViewModel;
 
@@ -42,8 +40,6 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
         if (cardNumber != null) {
             args.putString("EXTRA_CARD_NUMBER", cardNumber);
         }
-
-        cardLogosDisabled = dropInRequest.areCardLogosDisabled();
 
         AddCardFragment instance = new AddCardFragment();
         instance.setArguments(args);
@@ -57,7 +53,10 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
         cardForm = view.findViewById(R.id.bt_card_form);
         supportedCardTypesView = view.findViewById(R.id.bt_supported_card_types);
 
-        if (cardLogosDisabled) {
+        Bundle args = getArguments();
+        DropInRequest dropInRequest = (DropInRequest) args.getParcelable("EXTRA_DROP_IN_REQUEST");
+
+        if (dropInRequest.areCardLogosDisabled()) {
             supportedCardTypesView.setVisibility(View.GONE);
         }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/AddCardFragment.java
@@ -26,7 +26,9 @@ public class AddCardFragment extends DropInFragment implements OnCardFormSubmitL
     @VisibleForTesting
     CardForm cardForm;
 
-    private AccessibleSupportedCardTypesView supportedCardTypesView;
+    @VisibleForTesting
+    AccessibleSupportedCardTypesView supportedCardTypesView;
+
     private AnimatedButtonView animatedButtonView;
 
     @VisibleForTesting

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInRequest.java
@@ -24,6 +24,7 @@ public class DropInRequest implements Parcelable {
     private boolean payPalDisabled = false;
     private boolean venmoDisabled = false;
     private boolean cardDisabled = false;
+    private boolean cardLogosDisabled = false;
     private boolean vaultCardDefaultValue = true;
     private boolean allowVaultCardOverride = false;
 
@@ -96,6 +97,15 @@ public class DropInRequest implements Parcelable {
      */
     public void setCardDisabled(boolean disableCard) {
         cardDisabled = disableCard;
+    }
+
+    /**
+     * This method is optional.
+     *
+     * @param disableCardLogos If set to true, hides all card logos in Drop-in. Default value is false.
+     */
+    public void setCardLogosDisabled(boolean disableCardLogos) {
+        cardLogosDisabled = disableCardLogos;
     }
 
     /**
@@ -211,6 +221,13 @@ public class DropInRequest implements Parcelable {
     }
 
     /**
+     * @return If card logos are disabled in Drop-in
+     */
+    public boolean areCardLogosDisabled() {
+        return cardLogosDisabled;
+    }
+
+    /**
      * @return The Google Pay Request {@link GooglePayRequest} for the transaction.
      */
     @Nullable
@@ -287,6 +304,7 @@ public class DropInRequest implements Parcelable {
         dest.writeByte(payPalDisabled ? (byte) 1 : (byte) 0);
         dest.writeByte(venmoDisabled ? (byte) 1 : (byte) 0);
         dest.writeByte(cardDisabled ? (byte) 1 : (byte) 0);
+        dest.writeByte(cardLogosDisabled ? (byte) 1 : (byte) 0);
         dest.writeParcelable(threeDSecureRequest, 0);
         dest.writeByte(maskCardNumber ? (byte) 1 : (byte) 0);
         dest.writeByte(maskSecurityCode ? (byte) 1 : (byte) 0);
@@ -304,6 +322,7 @@ public class DropInRequest implements Parcelable {
         payPalDisabled = in.readByte() != 0;
         venmoDisabled = in.readByte() != 0;
         cardDisabled = in.readByte() != 0;
+        cardLogosDisabled = in.readByte() != 0;
         threeDSecureRequest = in.readParcelable(ThreeDSecureRequest.class.getClassLoader());
         maskCardNumber = in.readByte() != 0;
         maskSecurityCode = in.readByte() != 0;

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInRequestUnitTest.java
@@ -73,6 +73,7 @@ public class DropInRequestUnitTest {
         dropInRequest.setAllowVaultCardOverride(true);
         dropInRequest.setVaultCardDefaultValue(true);
         dropInRequest.setCardholderNameStatus(CardForm.FIELD_OPTIONAL);
+        dropInRequest.setCardLogosDisabled(true);
 
         assertNotNull(dropInRequest.getGooglePayRequest());
         assertEquals("10", dropInRequest.getGooglePayRequest().getTransactionInfo().getTotalPrice());
@@ -94,6 +95,7 @@ public class DropInRequestUnitTest {
         assertTrue(dropInRequest.isPayPalDisabled());
         assertTrue(dropInRequest.isVenmoDisabled());
         assertTrue(dropInRequest.isCardDisabled());
+        assertTrue(dropInRequest.areCardLogosDisabled());
         assertNotNull(dropInRequest.getThreeDSecureRequest());
         assertEquals("abc-123", dropInRequest.getThreeDSecureRequest().getNonce());
         assertEquals("2", dropInRequest.getThreeDSecureRequest().getVersionRequested());


### PR DESCRIPTION
### Summary of changes

 - Add `DropInRequest.setCardLogosDisabled()` to hide card logos on the credit card form if desired
    - This is a merchant requested feature to resolve a live issue
    - iOS PR: https://github.com/braintree/braintree-ios-drop-in/pull/423

### Visuals
| Without `setCardLogosDisabled` | With `setCardLogosDisabled` |
|-----|-----|
|![Screenshot_20230807_134500](https://github.com/braintree/braintree-android-drop-in/assets/20733831/76114a8b-45b7-41ca-9722-2b1227f7730a)|![Screenshot_20230807_134616](https://github.com/braintree/braintree-android-drop-in/assets/20733831/09cb7996-d115-4a96-8f56-937fe0b42e38)|

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
