### PR TITLE
[5.x] Bump braintree_android to 3.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Bump braintree_android version to 3.21.0
+* Bump braintree_android version to 3.21.1
 
 ## 5.4.1
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     api 'com.braintreepayments.api:braintree:3.21.0'
     api 'com.braintreepayments:card-form:5.1.1'
-    api 'com.braintreepayments.api:three-d-secure:3.21.0'
+    api 'com.braintreepayments.api:three-d-secure:3.21.1'
 
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    api 'com.braintreepayments.api:braintree:3.21.0'
+    api 'com.braintreepayments.api:braintree:3.21.1'
     api 'com.braintreepayments:card-form:5.1.1'
     api 'com.braintreepayments.api:three-d-secure:3.21.1'
 


### PR DESCRIPTION
### Summary of changes

 - Bump braintree_android version to 3.21.1

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
