### PR TITLE
Make PaymentMethodClient Methods Public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Add `PaymentMethodClient` with API `getPaymentMethodNonces` and `deletePaymentMethod`
+
 ## 6.11.0
 
 * Add California Privacy Laws notice of collection to credit card form

--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/AddCardFragmentUITest.kt
@@ -16,15 +16,23 @@ import com.braintreepayments.cardform.utils.CardType
 import junit.framework.TestCase.assertNull
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AddCardFragmentUITest {
 
+    private val args: Bundle = Bundle()
+
+    @Before
+    fun setup() {
+        args.putParcelable("EXTRA_DROP_IN_REQUEST", DropInRequest())
+    }
+
     @Test
     fun whenStateIsRESUMED_buttonTextIsAddCard() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -39,7 +47,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_cardNumberFieldIsFocused() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         onView(withId(R.id.bt_card_form_card_number)).check(matches(isFocused()))
@@ -47,7 +55,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_andNonCardNumberError_doesNotShowError() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -61,7 +69,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_sendsAnalyticsEvent() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -77,7 +85,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onSubmitButtonClick_whenCardFormValid_showsLoader() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -93,7 +101,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onSubmitButtonClick_whenCardFormNotValid_showsSubmitButton() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -109,7 +117,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onSubmitButtonClick_whenCardTypeNotSupported_showsSubmitButton() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -125,7 +133,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_onSubmitButtonClickWithValidCardNumber_sendsAddCardEvent() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -149,7 +157,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_whenCardNumberValidationErrorsArePresentInViewModel_displaysErrorsInlineToUser() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -164,7 +172,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_whenCardNumberIsDuplicate_displaysErrorsInlineToUser() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -179,7 +187,7 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_whenCardFromInvalid_showsSubmitButton() {
-        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, null, R.style.bt_drop_in_activity_theme)
+        val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)
         scenario.moveToState(Lifecycle.State.RESUMED)
 
         scenario.onFragment { fragment ->
@@ -196,7 +204,6 @@ class AddCardFragmentUITest {
         val dropInRequest = DropInRequest()
         dropInRequest.setCardLogosDisabled(true);
 
-        val args = Bundle()
         args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
@@ -212,10 +219,6 @@ class AddCardFragmentUITest {
 
     @Test
     fun whenStateIsRESUMED_andCardLogosEnabled_supportedCardTypesViewIsVISIBLE() {
-        val dropInRequest = DropInRequest()
-
-        val args = Bundle()
-        args.putParcelable("EXTRA_DROP_IN_REQUEST", dropInRequest)
         args.putString("EXTRA_CARD_NUMBER", VISA)
 
         val scenario = FragmentScenario.launchInContainer(AddCardFragment::class.java, args, R.style.bt_drop_in_activity_theme)

--- a/Drop-In/src/main/java/com/braintreepayments/api/DeletePaymentMethodNonceCallback.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DeletePaymentMethodNonceCallback.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 /**
  * Callback for receiving result of {@link PaymentMethodClient#deletePaymentMethod(Context, PaymentMethodNonce, DeletePaymentMethodNonceCallback)}.
  */
-interface DeletePaymentMethodNonceCallback {
+public interface DeletePaymentMethodNonceCallback {
 
     /**
      * @param deletedNonce {@link PaymentMethodNonce}

--- a/Drop-In/src/main/java/com/braintreepayments/api/GetPaymentMethodNoncesCallback.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/GetPaymentMethodNoncesCallback.java
@@ -9,7 +9,7 @@ import java.util.List;
  * {@link PaymentMethodClient#getPaymentMethodNonces(GetPaymentMethodNoncesCallback)} and
  * {@link PaymentMethodClient#getPaymentMethodNonces(boolean, GetPaymentMethodNoncesCallback)}.
  */
-interface GetPaymentMethodNoncesCallback {
+public interface GetPaymentMethodNoncesCallback {
 
     /**
      * @param paymentMethodNonceList {@link PaymentMethodNonce} list

--- a/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Class used to retrieve a customer's payment methods.
  */
-class PaymentMethodClient {
+public class PaymentMethodClient {
 
     private static final String PAYMENT_METHOD_NONCE_COLLECTION_KEY = "paymentMethods";
     private static final String PAYMENT_METHOD_TYPE_KEY = "type";
@@ -33,7 +33,12 @@ class PaymentMethodClient {
 
     private final BraintreeClient braintreeClient;
 
-    PaymentMethodClient(BraintreeClient braintreeClient) {
+    /**
+     * Creates a new instance of {@link PaymentMethodClient}
+     *
+     * @param braintreeClient a {@link BraintreeClient}
+     */
+    public PaymentMethodClient(BraintreeClient braintreeClient) {
         this.braintreeClient = braintreeClient;
     }
 
@@ -68,7 +73,14 @@ class PaymentMethodClient {
         }
     }
 
-    void getPaymentMethodNonces(boolean defaultFirst, final GetPaymentMethodNoncesCallback callback) {
+    /**
+     * Retrieves the current list of {@link PaymentMethodNonce} for the current user.
+     *
+     * @param defaultFirst when {@code true}, the user's default payment method will be first in the
+     *                     list
+     * @param callback a {@link GetPaymentMethodNoncesCallback} to handle results
+     */
+    public void getPaymentMethodNonces(boolean defaultFirst, final GetPaymentMethodNoncesCallback callback) {
         final Uri uri = Uri.parse(ApiClient.versionedPath(ApiClient.PAYMENT_METHOD_ENDPOINT))
                 .buildUpon()
                 .appendQueryParameter("default_first", String.valueOf(defaultFirst))
@@ -95,7 +107,16 @@ class PaymentMethodClient {
         getPaymentMethodNonces(false, callback);
     }
 
-    void deletePaymentMethod(final Context context, final PaymentMethodNonce paymentMethodNonce, final DeletePaymentMethodNonceCallback callback) {
+    /**
+     * Deletes a payment method for the user whose ID was used to generate the {@link ClientToken}
+     * used to instantiate the {@link BraintreeClient}.
+     *
+     * @param context an Android {@link Context}
+     * @param paymentMethodNonce the {@link PaymentMethodNonce} that references a vaulted payment
+     *                           method to be deleted.
+     * @param callback a {@link DeletePaymentMethodNonceCallback} to handle results
+     */
+    public void deletePaymentMethod(final Context context, final PaymentMethodNonce paymentMethodNonce, final DeletePaymentMethodNonceCallback callback) {
         braintreeClient.getAuthorization(new AuthorizationCallback() {
             @Override
             public void onAuthorizationResult(@Nullable Authorization authorization, @Nullable Exception error) {


### PR DESCRIPTION
### Summary of changes

 - Make `PaymentMethodClient` public including `getPaymentMethodNonces`, `deletePaymentMethod` and associated callbacks
 - Fix integration tests failing due to missing fragment args

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
