### PR TITLE
Revert Kotlin Version to Align with BT Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         maven {


### PR DESCRIPTION
### Summary of changes

 - Revert Kotlin version to 1.7.10 to align with braintree_android kotlin version. Drop-in does not currently contain Kotlin source code, so this update is to resolve lint warnings for test.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
