### PR TITLE
Update braintree_android to 4.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android module dependency versions to `4.38.0`
+
 ## 6.12.0
 
 * Add `PaymentMethodClient` with API `getPaymentMethodNonces` and `deletePaymentMethod`

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.37.0"
+    ext.brainTreeVersion = "4.38.0"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Bump `braintree_android` module dependency versions to `4.38.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
