### PR TITLE
Upgrade to Android 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## unreleased
 
 * Bump braintree_android module dependency versions to `4.38.1`
-* Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34
+* Android 14 Support
+  * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34
 
 ## 6.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Bump braintree_android module dependency versions to `4.38.0`
+* Bump braintree_android module dependency versions to `4.38.1`
+* Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34
 
 ## 6.12.0
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -47,7 +47,9 @@ android {
         warning 'GradleCompatible'
         textReport true
         textOutput 'stdout'
-        disable 'InvalidPackage' // The Cardinal SDK is referencing the `javax.naming` package but it is unavailable
+        // RestrictedApi - Accessing Braintree Core SDK non-public methods
+        // InvalidPackage - The Cardinal SDK is referencing the `javax.naming` package but it is unavailable
+        disable 'RestrictedApi', 'InvalidPackage'
     }
 
     sourceSets {

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -44,12 +44,10 @@ android {
     }
 
     lintOptions {
-        warning 'GradleCompatible'
+        // RestrictedApi - Accessing Braintree Core SDK non-public methods
+        warning 'GradleCompatible', 'RestrictedApi'
         textReport true
         textOutput 'stdout'
-        // RestrictedApi - Accessing Braintree Core SDK non-public methods
-        // InvalidPackage - The Cardinal SDK is referencing the `javax.naming` package but it is unavailable
-        disable 'RestrictedApi', 'InvalidPackage'
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.38.0"
+    ext.brainTreeVersion = "4.38.1"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",
@@ -36,9 +36,9 @@ plugins {
 
 version '6.12.1-SNAPSHOT'
 ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     minSdkVersion = 21
-    targetSdkVersion = 33
+    targetSdkVersion = 34
     versionCode = 105
     versionName = version
 }


### PR DESCRIPTION
### Summary of changes

 - Update compile and target SDK version to API 31
 - Bump braintree_android to 4.38.1

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
