### PR TITLE
Remove Lint from Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,19 +31,6 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_KEY_FILE: ${{ env.SIGNING_KEY_FILE_PATH }}
-  static_analysis:
-    name: Static Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11.0.10'
-          distribution: 'zulu'
-      - name: Run Static Analysis
-        uses: ./.github/actions/static_analysis
   unit_test:
     name: Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary of changes

- Lint (gradle and detekt) was added to this repo for pull requests but it is not set up to run on release. Removing this step from the release process since the linting is run on each individual PR.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
