### PR TITLE
Fix NPE and Bump Core Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Bump brinatree_android module dependency versions to `4.39.0`
+* Bump braintree_android module dependency versions to `4.40.1`
+* Fix NPE when `DropInListener` is null
 
 ## 6.13.0
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -348,7 +348,7 @@ public class DropInClient {
     }
 
     void onDropInResult(DropInResult dropInResult) {
-        if (dropInResult != null) {
+        if (dropInResult != null && listener != null) {
             Exception error = dropInResult.getError();
             if (error != null) {
                 listener.onDropInFailure(error);

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInClientUnitTest.java
@@ -416,6 +416,16 @@ public class DropInClientUnitTest {
     }
 
     @Test
+    public void onDropInResult_whenListenerIsNull_doesNothing() {
+        DropInClientParams params = new DropInClientParams();
+        DropInClient sut = new DropInClient(params);
+
+
+        DropInResult dropInResult = new DropInResult();
+        sut.onDropInResult(dropInResult);
+    }
+
+    @Test
     public void invalidateClientToken_forwardsInvocationIntoBraintreeClient() {
         BraintreeClient braintreeClient = new MockBraintreeClientBuilder().build();
         DropInClientParams params = new DropInClientParams()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.39.0"
+    ext.brainTreeVersion = "4.40.1"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Fix NPE when `DropInListener` is null
 - Bump `braintree_android` version to latest

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
