### PR TITLE
Remove unnecessary play services dependency

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
     implementation 'androidx.cardview:cardview:1.0.0'
 
-    implementation 'com.google.android.gms:play-services-wallet:16.0.1'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'
     implementation 'io.card:android-sdk:5.5.1'
 

--- a/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/demo/MainActivity.java
@@ -284,6 +284,7 @@ public class MainActivity extends BaseActivity implements DropInListener {
                 .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
                 .build());
         googlePayRequest.setEmailRequired(true);
+        googlePayRequest.setCountryCode("BR");
         return googlePayRequest;
     }
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     api 'com.braintreepayments:card-form:5.4.0'
 
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.gms:play-services-wallet:16.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'


### PR DESCRIPTION
### Summary of changes

 - Drop-in contained an unnecessary additional dependency of play service wallet, using an older dependency than core. Remove dependencies so that drop-in gets it's play services wallet dependency from the core SDK.
 - Update country code in demo app to fix prod error.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
