### PR TITLE
Update Braintree Core to 4.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Bump braintree_android module dependency versions to `4.48.0`
+
 ## 6.16.0
 
 * Bump braintree_android module dependency versions to `4.45.0`

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInClient.java
@@ -44,8 +44,15 @@ public class DropInClient {
             customUrlScheme = dropInRequest.getCustomUrlScheme();
         }
 
-        BraintreeOptions braintreeOptions =
-                new BraintreeOptions(context, null, customUrlScheme, authorization, clientTokenProvider, IntegrationType.DROP_IN);
+        BraintreeOptions braintreeOptions = new BraintreeOptions(
+                context,
+                null,
+                customUrlScheme,
+                null,
+                authorization,
+                clientTokenProvider,
+                IntegrationType.DROP_IN
+        );
 
         BraintreeClient braintreeClient = new BraintreeClient(braintreeOptions);
         return new DropInClientParams()

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInInternalClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInInternalClient.java
@@ -40,8 +40,15 @@ class DropInInternalClient {
     private static DropInInternalClientParams createDefaultParams(Context context, String authorization, DropInRequest dropInRequest, String sessionId) {
 
         String customUrlScheme = dropInRequest.getCustomUrlScheme();
-        BraintreeOptions braintreeOptions =
-                new BraintreeOptions(context, sessionId, customUrlScheme, authorization, null, IntegrationType.DROP_IN);
+        BraintreeOptions braintreeOptions = new BraintreeOptions(
+                context,
+                sessionId,
+                customUrlScheme,
+                null,
+                authorization,
+                null,
+                IntegrationType.DROP_IN
+        );
 
         BraintreeClient braintreeClient = new BraintreeClient(braintreeOptions);
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInActivityUnitTest.kt
@@ -1200,7 +1200,7 @@ class DropInActivityUnitTest {
         val metadata = JSONObject()
         val returnUrlScheme = "sample-scheme"
         val browserSwitchRequest =
-            BrowserSwitchRequest(requestCode, url, metadata, returnUrlScheme, true)
+            BrowserSwitchRequest(requestCode, url, metadata, returnUrlScheme, null, true)
         return BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, browserSwitchRequest)
     }
 

--- a/Drop-In/src/test/java/com/braintreepayments/api/DropInInternalClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/DropInInternalClientUnitTest.java
@@ -1591,7 +1591,7 @@ public class DropInInternalClientUnitTest {
         Uri url = Uri.parse("www.example.com");
         String returnUrlScheme = "sample-scheme";
         BrowserSwitchRequest browserSwitchRequest = new BrowserSwitchRequest(
-                requestCode, url, new JSONObject(), returnUrlScheme, true);
+                requestCode, url, new JSONObject(), returnUrlScheme, null, true);
         return new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, browserSwitchRequest);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.45.0"
+    ext.brainTreeVersion = "4.48.0"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Bump `braintree_android` module dependency versions to `4.48.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
