### PR TITLE
Update Braintree Core to 4.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Bump braintree_android module dependency versions to `4.48.0`
+* Bump braintree_android module dependency versions to `4.49.1`
 
 ## 6.16.0
 

--- a/Drop-In/build.gradle
+++ b/Drop-In/build.gradle
@@ -65,8 +65,8 @@ android {
 dependencies {
     // TODO: consider making this api in core to allow for PaymentType and other @IntDef / @StringDef constants to work for merchants
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.fragment:fragment:1.4.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation 'androidx.fragment:fragment:1.7.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.7.0'
 
     api deps.braintreeCore
     api deps.threeDSecure
@@ -102,8 +102,8 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.fragment:fragment-testing:1.3.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.fragment:fragment-testing:1.7.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     androidTestImplementation 'org.mockito:mockito-core:5.2.0'
 }
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
@@ -152,7 +152,7 @@ public class PaymentMethodClient {
                     callback.onResult(null, graphQLError);
                 }
 
-                braintreeClient.sendGraphQLPOST(base.toString(), (responseBody, httpError) -> {
+                braintreeClient.sendGraphQLPOST(base, (responseBody, httpError) -> {
                     if (responseBody != null) {
                         callback.onResult(paymentMethodNonce, null);
                         braintreeClient.sendAnalyticsEvent("delete-payment-methods.succeeded");

--- a/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
+++ b/Drop-In/src/sharedTest/java/com/braintreepayments/api/MockBraintreeClientBuilder.java
@@ -118,7 +118,7 @@ public class MockBraintreeClientBuilder {
                 callback.onResult(null, sendGraphQLPOSTError);
             }
             return null;
-        }).when(braintreeClient).sendGraphQLPOST(anyString(), any(HttpResponseCallback.class));
+        }).when(braintreeClient).sendGraphQLPOST(any(), any(HttpResponseCallback.class));
 
         return braintreeClient;
     }

--- a/Drop-In/src/test/java/com/braintreepayments/api/PaymentMethodClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/PaymentMethodClientUnitTest.java
@@ -291,7 +291,7 @@ public class PaymentMethodClientUnitTest {
         assertEquals("A client token with a customer id must be used to delete a payment method nonce.",
                 captor.getValue().getMessage());
 
-        verify(braintreeClient, never()).sendGraphQLPOST(anyString(), any(HttpResponseCallback.class));
+        verify(braintreeClient, never()).sendGraphQLPOST(any(), any(HttpResponseCallback.class));
     }
 
     @Test
@@ -374,10 +374,10 @@ public class PaymentMethodClientUnitTest {
 
         verify(braintreeClient).getIntegrationType();
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);
         verify(braintreeClient).sendGraphQLPOST(captor.capture(), any(HttpResponseCallback.class));
 
-        JSONObject graphQlRequest = new JSONObject(captor.getValue());
+        JSONObject graphQlRequest = captor.getValue();
 
         String expectedGraphQLQuery = GraphQLQueryHelper.getQuery(
                 ApplicationProvider.getApplicationContext(), R.raw.delete_payment_method_mutation);

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    ext.brainTreeVersion = "4.48.0"
+    ext.brainTreeVersion = "4.49.1"
 
     ext.deps = [
             "braintreeCore" : "com.braintreepayments.api:braintree-core:$brainTreeVersion",


### PR DESCRIPTION
### Summary of changes

 - Bump `braintree_android` module dependency versions to `4.49.1`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
