### PR TITLE
Be defensive to empty Intent in DropInActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Bump braintree_android module dependency versions to `4.49.1`
+* Fix DropInActivity crash when Intent extras unavailable
 
 ## 6.16.0
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInActivity.java
@@ -72,16 +72,19 @@ public class DropInActivity extends AppCompatActivity {
             return;
         }
 
+        dropInRequest = getDropInRequest(intent);
+        if (dropInRequest == null) {
+            finishDropInWithError(new IllegalStateException("DropInRequest not found in Intent extras"));
+            return;
+        }
+
         if (dropInInternalClient == null) {
             String authorization = intent.getStringExtra(DropInClient.EXTRA_AUTHORIZATION);
             String sessionId = intent.getStringExtra(DropInClient.EXTRA_SESSION_ID);
-            DropInRequest dropInRequest = getDropInRequest(intent);
             dropInInternalClient = new DropInInternalClient(this, authorization, sessionId, dropInRequest);
         }
 
         alertPresenter = new AlertPresenter();
-        dropInRequest = getDropInRequest(getIntent());
-
         dropInViewModel = new ViewModelProvider(this).get(DropInViewModel.class);
         fragmentContainerView = findViewById(R.id.fragment_container_view);
 
@@ -121,6 +124,9 @@ public class DropInActivity extends AppCompatActivity {
 
     private DropInRequest getDropInRequest(Intent intent) {
         Bundle bundle = intent.getParcelableExtra(DropInClient.EXTRA_CHECKOUT_REQUEST_BUNDLE);
+        if (bundle == null) {
+            return null;
+        }
         bundle.setClassLoader(DropInRequest.class.getClassLoader());
         return bundle.getParcelable(DropInClient.EXTRA_CHECKOUT_REQUEST);
     }


### PR DESCRIPTION
### Summary of changes

Numerous issues have been raised containing a similar stack trace:

https://github.com/braintree/braintree-android-drop-in/issues/494, https://github.com/braintree/braintree-android-drop-in/issues/487, https://github.com/braintree/braintree-android-drop-in/issues/404, https://github.com/braintree/braintree-android-drop-in/issues/403, https://github.com/braintree/braintree-android-drop-in/issues/379, https://github.com/braintree/braintree-android-drop-in/issues/356

```console
java.lang.RuntimeException: Unable to start activity ComponentInfo{it.elbuild.ilceppo/com.braintreepayments.api.DropInActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.os.Bundle.setClassLoader(java.lang.ClassLoader)' on a null object reference
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4169)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4325)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at android.app.ActivityThread.main(ActivityThread.java:8757)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.os.Bundle.setClassLoader(java.lang.ClassLoader)' on a null object reference
        at com.braintreepayments.api.DropInActivity.getDropInRequest(DropInActivity.java:124)
        at com.braintreepayments.api.DropInActivity.onCreate(DropInActivity.java:78)
        at android.app.Activity.performCreate(Activity.java:8591)
        at android.app.Activity.performCreate(Activity.java:8570)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1384)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4150)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4325) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:226) 
        at android.os.Looper.loop(Looper.java:313) 
        at android.app.ActivityThread.main(ActivityThread.java:8757) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

It is not 100% clear what causes this, however, if the Activity is relaunched after _process death_, its original `Intent` may no longer be available (with extra data).

As a result, `intent.getParcelableExtra(DropInClient.EXTRA_CHECKOUT_REQUEST_BUNDLE)` returns null, cascading to the behavior above.

We can prevent a crash in this library code by being defensive to the situation. If the intent extras are not available, we can simply finish the activity instead of crashing.

 ### Checklist

 - [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@jamesonwilliams

