### PR TITLE
fix name collision

### DIFF
--- a/Drop-In/src/androidTest/java/com/braintreepayments/api/GraphQLQueryHelperTest.kt
+++ b/Drop-In/src/androidTest/java/com/braintreepayments/api/GraphQLQueryHelperTest.kt
@@ -3,7 +3,7 @@ package com.braintreepayments.api
 import android.content.res.Resources.NotFoundException
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import com.braintreepayments.api.GraphQLQueryHelper.getQuery
+import com.braintreepayments.api.GraphQLQueryHelper2.getQuery
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/Drop-In/src/main/java/com/braintreepayments/api/GraphQLQueryHelper2.kt
+++ b/Drop-In/src/main/java/com/braintreepayments/api/GraphQLQueryHelper2.kt
@@ -5,7 +5,7 @@ import android.content.res.Resources
 import java.io.IOException
 import java.io.InputStream
 
-internal object GraphQLQueryHelper {
+internal object GraphQLQueryHelper2 {
     @JvmStatic
     @Throws(Resources.NotFoundException::class, IOException::class)
     fun getQuery(context: Context, queryResource: Int): String {

--- a/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/PaymentMethodClient.java
@@ -140,7 +140,7 @@ public class PaymentMethodClient {
                             .integration(braintreeClient.getIntegrationType())
                             .build());
 
-                    base.put(GraphQLConstants.Keys.QUERY, GraphQLQueryHelper.getQuery(
+                    base.put(GraphQLConstants.Keys.QUERY, GraphQLQueryHelper2.getQuery(
                             context, R.raw.delete_payment_method_mutation));
                     input.put(SINGLE_USE_TOKEN_ID, paymentMethodNonce.getString());
                     variables.put(INPUT, input);

--- a/Drop-In/src/test/java/com/braintreepayments/api/PaymentMethodClientUnitTest.java
+++ b/Drop-In/src/test/java/com/braintreepayments/api/PaymentMethodClientUnitTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -379,7 +378,7 @@ public class PaymentMethodClientUnitTest {
 
         JSONObject graphQlRequest = captor.getValue();
 
-        String expectedGraphQLQuery = GraphQLQueryHelper.getQuery(
+        String expectedGraphQLQuery = GraphQLQueryHelper2.getQuery(
                 ApplicationProvider.getApplicationContext(), R.raw.delete_payment_method_mutation);
         assertEquals(expectedGraphQLQuery, graphQlRequest.getString(GraphQLConstants.Keys.QUERY));
 


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Fix name collision that is causing [build](https://github.com/braintree/braintree-android-drop-in/actions/runs/14579928184) to fail. 

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
