### PR TITLE
Fix lifecycle crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Drop-In Release Notes
 
+## unreleased
+
+* Fix lifecycle crashes (fixes #494, #487, #404, #403, #379, #356)
+
 ## 6.17.0
 
 * Bump braintree_android module dependency versions to `4.50.0`

--- a/Drop-In/src/main/java/com/braintreepayments/api/DropInViewModel.java
+++ b/Drop-In/src/main/java/com/braintreepayments/api/DropInViewModel.java
@@ -2,6 +2,7 @@ package com.braintreepayments.api;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.SavedStateHandle;
 import androidx.lifecycle.ViewModel;
 
 import com.braintreepayments.cardform.utils.CardType;
@@ -12,14 +13,25 @@ import java.util.List;
 
 public class DropInViewModel extends ViewModel {
 
-    private final MutableLiveData<BottomSheetState> bottomSheetState = new MutableLiveData<>(BottomSheetState.HIDDEN);
-    private final MutableLiveData<DropInState> dropInState = new MutableLiveData<>(DropInState.IDLE);
+    public DropInViewModel(SavedStateHandle savedStateHandle) {
+        bottomSheetState = savedStateHandle.getLiveData("bottomSheetState", BottomSheetState.HIDDEN);
+        dropInState = savedStateHandle.getLiveData("dropInState", DropInState.IDLE);
 
-    private final MutableLiveData<List<DropInPaymentMethod>> supportedPaymentMethods = new MutableLiveData<>();
-    private final MutableLiveData<List<PaymentMethodNonce>> vaultedPaymentMethods = new MutableLiveData<>();
-    private final MutableLiveData<List<CardType>> supportedCardTypes = new MutableLiveData<>();
-    private final MutableLiveData<Exception> cardTokenizationError = new MutableLiveData<>();
-    private final MutableLiveData<Exception> userCanceledError = new MutableLiveData<>();
+        supportedPaymentMethods = savedStateHandle.getLiveData("supportedPaymentMethods");
+        vaultedPaymentMethods = savedStateHandle.getLiveData("vaultedPaymentMethods");
+        supportedCardTypes  = savedStateHandle.getLiveData("supportedCardTypes");
+        cardTokenizationError = savedStateHandle.getLiveData("cardTokenizationError");
+        userCanceledError = savedStateHandle.getLiveData("userCanceledError");
+    }
+
+    private final MutableLiveData<BottomSheetState> bottomSheetState;
+    private final MutableLiveData<DropInState> dropInState;
+
+    private final MutableLiveData<List<DropInPaymentMethod>> supportedPaymentMethods;
+    private final MutableLiveData<List<PaymentMethodNonce>> vaultedPaymentMethods;
+    private final MutableLiveData<List<CardType>> supportedCardTypes;
+    private final MutableLiveData<Exception> cardTokenizationError;
+    private final MutableLiveData<Exception> userCanceledError;
 
     LiveData<BottomSheetState> getBottomSheetState() {
         return bottomSheetState;


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - fixes #494, #487, #404, #403, #379, #356 by adding proper handling in onSaveInstanceState (to fix crash)
 - use LiveData backed by savedStateHandle so the result processing flow works with activity recreation

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@
- @scana
- @sikora-whatnot
